### PR TITLE
Remove test cfg's

### DIFF
--- a/scale-encode/src/impls/mod.rs
+++ b/scale-encode/src/impls/mod.rs
@@ -885,7 +885,6 @@ mod test {
         encode_type::<_, Foo>(source).unwrap_err();
     }
 
-    #[cfg(feature = "bits")]
     #[test]
     fn bits_roundtrip_ok() {
         use bitvec::{
@@ -934,7 +933,6 @@ mod test {
         );
     }
 
-    #[cfg(feature = "primitive-types")]
     #[test]
     fn hxxx_types_roundtrip_ok() {
         use ::primitive_types::{H128, H160, H256, H384, H512, H768};
@@ -1006,7 +1004,6 @@ mod test {
         )
     }
 
-    #[cfg(feature = "derive")]
     #[test]
     fn encode_as_fields_via_macro_works() {
         #[derive(TypeInfo, Encode)]


### PR DESCRIPTION
`cargo test` at the workspace level will ignore these even if `--no-default-features` is used, and in any case we don't check that they work properly via CI, so let's just assume that tests have default features enabled and keep it simple!