### PR TITLE
Improve EncodeAsFields trait with iterator over Fields

### DIFF
--- a/scale-encode-derive/src/lib.rs
+++ b/scale-encode-derive/src/lib.rs
@@ -190,10 +190,10 @@ fn generate_struct_impl(
             }
         }
         impl #impl_generics #path_to_scale_encode::EncodeAsFields for #path_to_type #ty_generics #where_clause {
-            fn encode_as_fields_to(
+            fn encode_as_fields_to<'__encode_as_field_lt, I: std::iter::Iterator<Item=#path_to_scale_encode::Field<'__encode_as_field_lt>> + Clone>(
                 &self,
                 // long variable names to prevent conflict with struct field names:
-                __encode_as_type_fields: &[#path_to_scale_encode::PortableField],
+                __encode_as_type_fields: I,
                 __encode_as_type_types: &#path_to_scale_encode::PortableRegistry,
                 __encode_as_type_out: &mut Vec<u8>
             ) -> Result<(), #path_to_scale_encode::Error> {

--- a/scale-encode-derive/src/lib.rs
+++ b/scale-encode-derive/src/lib.rs
@@ -190,7 +190,7 @@ fn generate_struct_impl(
             }
         }
         impl #impl_generics #path_to_scale_encode::EncodeAsFields for #path_to_type #ty_generics #where_clause {
-            fn encode_as_fields_to<'__encode_as_field_lt, I: std::iter::Iterator<Item=#path_to_scale_encode::Field<'__encode_as_field_lt>> + Clone>(
+            fn encode_as_fields_to<'__encode_as_field_lt, I: #path_to_scale_encode::FieldIter<'__encode_as_field_lt>>(
                 &self,
                 // long variable names to prevent conflict with struct field names:
                 __encode_as_type_fields: I,

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -26,7 +26,7 @@ primitive-types = ["dep:primitive-types"]
 bits = ["dep:scale-bits"]
 
 [dependencies]
-scale-info = { version = "2.3.0", features = ["bit-vec"] }
+scale-info = { version = "2.7.0", features = ["bit-vec"] }
 thiserror = "1.0.37"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 scale-bits = { version = "0.3.0", default-features = false, features = ["scale-info"], optional = true }

--- a/scale-encode/src/impls/bits.rs
+++ b/scale-encode/src/impls/bits.rs
@@ -31,7 +31,7 @@ impl EncodeAsType for scale_bits::Bits {
             .resolve(type_id)
             .ok_or_else(|| Error::new(ErrorKind::TypeNotFound(type_id)))?;
 
-        if let TypeDef::BitSequence(ty) = ty.type_def() {
+        if let TypeDef::BitSequence(ty) = &ty.type_def {
             let Ok(format) = scale_bits::Format::from_metadata(ty, types) else {
                 return Err(wrong_shape(type_id))
             };

--- a/scale-encode/src/impls/composite.rs
+++ b/scale-encode/src/impls/composite.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     error::{Error, ErrorKind, Kind, Location},
-    EncodeAsFields, EncodeAsType, Field,
+    EncodeAsFields, EncodeAsType, Field, FieldIter,
 };
 use scale_info::{PortableRegistry, TypeDef};
 use std::collections::HashMap;
@@ -132,7 +132,7 @@ impl<'a, Vals> EncodeAsFields for Composite<Vals>
 where
     Vals: ExactSizeIterator<Item = (Option<&'a str>, &'a dyn EncodeAsType)> + Clone,
 {
-    fn encode_as_fields_to<'b, I: Iterator<Item = Field<'b>> + Clone>(
+    fn encode_as_fields_to<'b, I: FieldIter<'b>>(
         &self,
         fields: I,
         types: &PortableRegistry,

--- a/scale-encode/src/impls/composite.rs
+++ b/scale-encode/src/impls/composite.rs
@@ -101,7 +101,7 @@ where
                 let fields = composite
                     .fields()
                     .iter()
-                    .map(|f| Field::new(f.ty().id(), f.name()));
+                    .map(|f| Field::new(f.ty().id(), f.name().map(|n| &**n)));
                 self.encode_as_fields_to(fields, types, out)
             }
             // We may have skipped through to some primitive or other type.

--- a/scale-encode/src/impls/composite.rs
+++ b/scale-encode/src/impls/composite.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     error::{Error, ErrorKind, Kind, Location},
-    EncodeAsFields, EncodeAsType,
+    EncodeAsFields, EncodeAsType, Field,
 };
 use scale_info::{PortableRegistry, TypeDef};
 use std::collections::HashMap;
@@ -79,8 +79,8 @@ where
                         .encode_as_type_to(type_id, types, out);
                 }
 
-                let fields = tuple.fields();
-                self.encode_as_field_ids_to(fields, types, out)
+                let fields = tuple.fields().iter().map(|f| Field::unnamed(f.id()));
+                self.encode_as_fields_to(fields, types, out)
             }
             // If we see a composite type, it has either named fields or !=1 unnamed fields.
             TypeDef::Composite(composite) => {
@@ -98,7 +98,10 @@ where
                         .encode_as_type_to(type_id, types, out);
                 }
 
-                let fields = composite.fields();
+                let fields = composite
+                    .fields()
+                    .iter()
+                    .map(|f| Field::new(f.ty().id(), f.name()));
                 self.encode_as_fields_to(fields, types, out)
             }
             // We may have skipped through to some primitive or other type.
@@ -129,9 +132,9 @@ impl<'a, Vals> EncodeAsFields for Composite<Vals>
 where
     Vals: ExactSizeIterator<Item = (Option<&'a str>, &'a dyn EncodeAsType)> + Clone,
 {
-    fn encode_as_fields_to(
+    fn encode_as_fields_to<'b, I: Iterator<Item = Field<'b>> + Clone>(
         &self,
-        fields: &[crate::PortableField],
+        fields: I,
         types: &PortableRegistry,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
@@ -140,7 +143,7 @@ where
         // Both the target and source type have to have named fields for us to use
         // names to line them up.
         let is_named = {
-            let is_target_named = fields.iter().any(|f| f.name().is_some());
+            let is_target_named = fields.clone().any(|f| f.name().is_some());
             let is_source_named = vals_iter.clone().any(|(name, _)| name.is_some());
             is_target_named && is_source_named
         };
@@ -156,35 +159,37 @@ where
 
             for field in fields {
                 // Find the field in our source type:
-                let name = field.name().map(|n| &**n).unwrap_or("");
+                let name = field.name().unwrap_or("");
                 let Some(value) = source_fields_by_name.get(name) else {
                     return Err(Error::new(ErrorKind::CannotFindField { name: name.to_string() }))
                 };
 
                 // Encode the value to the output:
                 value
-                    .encode_as_type_to(field.ty().id(), types, out)
+                    .encode_as_type_to(field.id(), types, out)
                     .map_err(|e| e.at_field(name.to_string()))?;
             }
 
             Ok(())
         } else {
+            let fields_len = fields.clone().count();
+
             // target fields aren't named, so encode by order only. We need the field length
             // to line up for this to work.
-            if fields.len() != vals_iter.len() {
+            if fields_len != vals_iter.len() {
                 return Err(Error::new(ErrorKind::WrongLength {
                     actual_len: vals_iter.len(),
-                    expected_len: fields.len(),
+                    expected_len: fields_len,
                 }));
             }
 
-            for (idx, (field, (name, val))) in fields.iter().zip(vals_iter).enumerate() {
+            for (idx, (field, (name, val))) in fields.zip(vals_iter).enumerate() {
                 let loc = if let Some(name) = name {
                     Location::field(name.to_string())
                 } else {
                     Location::idx(idx)
                 };
-                val.encode_as_type_to(field.ty().id(), types, out)
+                val.encode_as_type_to(field.id(), types, out)
                     .map_err(|e| e.at(loc))?;
             }
             Ok(())

--- a/scale-encode/src/impls/mod.rs
+++ b/scale-encode/src/impls/mod.rs
@@ -26,7 +26,7 @@ pub use composite::Composite;
 pub use variant::Variant;
 
 use crate::error::{Error, ErrorKind, Kind};
-use crate::{EncodeAsFields, EncodeAsType, Field};
+use crate::{EncodeAsFields, EncodeAsType, FieldIter};
 use codec::{Compact, Encode};
 use core::num::{
     NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
@@ -399,7 +399,7 @@ impl<K: AsRef<str>, V: EncodeAsType> EncodeAsType for BTreeMap<K, V> {
     }
 }
 impl<K: AsRef<str>, V: EncodeAsType> EncodeAsFields for BTreeMap<K, V> {
-    fn encode_as_fields_to<'a, I: Iterator<Item = Field<'a>> + Clone>(
+    fn encode_as_fields_to<'a, I: FieldIter<'a>>(
         &self,
         fields: I,
         types: &PortableRegistry,
@@ -525,7 +525,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::EncodeAsFields;
+    use crate::{EncodeAsFields, Field};
     use codec::Decode;
     use scale_info::TypeInfo;
     use std::fmt::Debug;

--- a/scale-encode/src/impls/mod.rs
+++ b/scale-encode/src/impls/mod.rs
@@ -588,7 +588,10 @@ mod test {
 
         let encoded_as_fields = match type_def {
             scale_info::TypeDef::Composite(c) => {
-                let fields = c.fields().iter().map(|f| Field::new(f.ty().id(), f.name()));
+                let fields = c
+                    .fields()
+                    .iter()
+                    .map(|f| Field::new(f.ty().id(), f.name().map(|n| &**n)));
                 value.encode_as_fields(fields, &types).unwrap()
             }
             scale_info::TypeDef::Tuple(t) => {

--- a/scale-encode/src/impls/mod.rs
+++ b/scale-encode/src/impls/mod.rs
@@ -52,7 +52,7 @@ impl EncodeAsType for bool {
             .resolve(type_id)
             .ok_or_else(|| Error::new(ErrorKind::TypeNotFound(type_id)))?;
 
-        if let TypeDef::Primitive(TypeDefPrimitive::Bool) = ty.type_def() {
+        if let TypeDef::Primitive(TypeDefPrimitive::Bool) = &ty.type_def {
             self.encode_to(out);
             Ok(())
         } else {
@@ -76,7 +76,7 @@ impl EncodeAsType for str {
             .resolve(type_id)
             .ok_or_else(|| Error::new(ErrorKind::TypeNotFound(type_id)))?;
 
-        if let TypeDef::Primitive(TypeDefPrimitive::Str) = ty.type_def() {
+        if let TypeDef::Primitive(TypeDefPrimitive::Str) = &ty.type_def {
             self.encode_to(out);
             Ok(())
         } else {
@@ -227,7 +227,7 @@ macro_rules! impl_encode_number {
                     Ok(())
                 }
 
-                match ty.type_def() {
+                match &ty.type_def {
                     TypeDef::Primitive(TypeDefPrimitive::U8) => try_num::<u8>(*self, type_id, out),
                     TypeDef::Primitive(TypeDefPrimitive::U16) => {
                         try_num::<u16>(*self, type_id, out)
@@ -255,7 +255,7 @@ macro_rules! impl_encode_number {
                         try_num::<i128>(*self, type_id, out)
                     }
                     TypeDef::Compact(c) => {
-                        let type_id = find_single_entry_with_same_repr(c.type_param().id(), types);
+                        let type_id = find_single_entry_with_same_repr(c.type_param.id, types);
 
                         let ty = types
                             .resolve(type_id)
@@ -274,7 +274,7 @@ macro_rules! impl_encode_number {
                             }};
                         }
 
-                        match ty.type_def() {
+                        match ty.type_def {
                             TypeDef::Primitive(TypeDefPrimitive::U8) => {
                                 try_compact_num!(*self, NumericKind::U8, out, u8)
                             }
@@ -387,7 +387,7 @@ impl<K: AsRef<str>, V: EncodeAsType> EncodeAsType for BTreeMap<K, V> {
             .resolve(type_id)
             .ok_or_else(|| Error::new(ErrorKind::TypeNotFound(type_id)))?;
 
-        if matches!(ty.type_def(), TypeDef::Array(_) | TypeDef::Sequence(_)) {
+        if matches!(ty.type_def, TypeDef::Array(_) | TypeDef::Sequence(_)) {
             encode_iterable_sequence_to(self.len(), self.values(), type_id, types, out)
         } else {
             Composite(
@@ -455,12 +455,12 @@ fn find_single_entry_with_same_repr(type_id: u32, types: &PortableRegistry) -> u
     let Some(ty) = types.resolve(type_id) else {
         return type_id
     };
-    match ty.type_def() {
-        TypeDef::Tuple(tuple) if tuple.fields().len() == 1 => {
-            find_single_entry_with_same_repr(tuple.fields()[0].id(), types)
+    match &ty.type_def {
+        TypeDef::Tuple(tuple) if tuple.fields.len() == 1 => {
+            find_single_entry_with_same_repr(tuple.fields[0].id, types)
         }
-        TypeDef::Composite(composite) if composite.fields().len() == 1 => {
-            find_single_entry_with_same_repr(composite.fields()[0].ty().id(), types)
+        TypeDef::Composite(composite) if composite.fields.len() == 1 => {
+            find_single_entry_with_same_repr(composite.fields[0].ty.id, types)
         }
         _ => type_id,
     }
@@ -482,18 +482,18 @@ where
         .resolve(type_id)
         .ok_or_else(|| Error::new(ErrorKind::TypeNotFound(type_id)))?;
 
-    match ty.type_def() {
+    match &ty.type_def {
         TypeDef::Array(arr) => {
-            if arr.len() == len as u32 {
+            if arr.len == len as u32 {
                 for (idx, item) in it.enumerate() {
-                    item.encode_as_type_to(arr.type_param().id(), types, out)
+                    item.encode_as_type_to(arr.type_param.id, types, out)
                         .map_err(|e| e.at_idx(idx))?;
                 }
                 Ok(())
             } else {
                 Err(Error::new(ErrorKind::WrongLength {
                     actual_len: len,
-                    expected_len: arr.len() as usize,
+                    expected_len: arr.len as usize,
                 }))
             }
         }
@@ -501,7 +501,7 @@ where
             // Sequences are prefixed with their compact encoded length:
             Compact(len as u32).encode_to(out);
             for (idx, item) in it.enumerate() {
-                item.encode_as_type_to(seq.type_param().id(), types, out)
+                item.encode_as_type_to(seq.type_param.id, types, out)
                     .map_err(|e| e.at_idx(idx))?;
             }
             Ok(())
@@ -509,11 +509,11 @@ where
         // if the target type is a basic newtype wrapper, then dig into that and try encoding to
         // the thing inside it. This is fairly common, and allowing this means that users don't have
         // to wrap things needlessly just to make types line up.
-        TypeDef::Tuple(tup) if tup.fields().len() == 1 => {
-            encode_iterable_sequence_to(len, it, tup.fields()[0].id(), types, out)
+        TypeDef::Tuple(tup) if tup.fields.len() == 1 => {
+            encode_iterable_sequence_to(len, it, tup.fields[0].id, types, out)
         }
-        TypeDef::Composite(com) if com.fields().len() == 1 => {
-            encode_iterable_sequence_to(len, it, com.fields()[0].ty().id(), types, out)
+        TypeDef::Composite(com) if com.fields.len() == 1 => {
+            encode_iterable_sequence_to(len, it, com.fields[0].ty.id, types, out)
         }
         _ => Err(Error::new(ErrorKind::WrongShape {
             actual: Kind::Array,
@@ -537,7 +537,7 @@ mod test {
         let id = types.register_type(&m);
         let portable_registry: PortableRegistry = types.into();
 
-        (id.id(), portable_registry)
+        (id.id, portable_registry)
     }
 
     fn encode_type<V: EncodeAsType, T: TypeInfo + 'static>(value: V) -> Result<Vec<u8>, Error> {
@@ -584,18 +584,18 @@ mod test {
         let encoded_other = other.encode();
 
         let (type_id, types) = make_type::<T>();
-        let type_def = types.resolve(type_id).unwrap().type_def();
+        let type_def = &types.resolve(type_id).unwrap().type_def;
 
         let encoded_as_fields = match type_def {
             scale_info::TypeDef::Composite(c) => {
                 let fields = c
-                    .fields()
+                    .fields
                     .iter()
-                    .map(|f| Field::new(f.ty().id(), f.name().map(|n| &**n)));
+                    .map(|f| Field::new(f.ty.id, f.name.as_deref()));
                 value.encode_as_fields(fields, &types).unwrap()
             }
             scale_info::TypeDef::Tuple(t) => {
-                let fields = t.fields().iter().map(|f| Field::unnamed(f.id()));
+                let fields = t.fields.iter().map(|f| Field::unnamed(f.id));
                 value.encode_as_fields(fields, &types).unwrap()
             }
             _ => {

--- a/scale-encode/src/impls/variant.rs
+++ b/scale-encode/src/impls/variant.rs
@@ -74,17 +74,17 @@ where
             .resolve(type_id)
             .ok_or_else(|| Error::new(ErrorKind::TypeNotFound(type_id)))?;
 
-        match ty.type_def() {
+        match &ty.type_def {
             TypeDef::Variant(var) => {
-                let vars = var.variants();
+                let vars = &var.variants;
                 let Some(v) = vars.iter().find(|v| v.name == self.name) else {
                     return Err(Error::new(ErrorKind::CannotFindVariant { name: self.name.to_string(), expected: type_id }));
                 };
-                v.index().encode_to(out);
+                v.index.encode_to(out);
                 let fields = v
-                    .fields()
+                    .fields
                     .iter()
-                    .map(|f| Field::new(f.ty().id(), f.name().map(|n| &**n)));
+                    .map(|f| Field::new(f.ty.id, f.name.as_deref()));
                 self.fields.encode_as_fields_to(fields, types, out)
             }
             _ => Err(Error::new(ErrorKind::WrongShape {

--- a/scale-encode/src/impls/variant.rs
+++ b/scale-encode/src/impls/variant.rs
@@ -81,7 +81,10 @@ where
                     return Err(Error::new(ErrorKind::CannotFindVariant { name: self.name.to_string(), expected: type_id }));
                 };
                 v.index().encode_to(out);
-                let fields = v.fields().iter().map(|f| Field::new(f.ty().id(), f.name()));
+                let fields = v
+                    .fields()
+                    .iter()
+                    .map(|f| Field::new(f.ty().id(), f.name().map(|n| &**n)));
                 self.fields.encode_as_fields_to(fields, types, out)
             }
             _ => Err(Error::new(ErrorKind::WrongShape {

--- a/scale-encode/src/impls/variant.rs
+++ b/scale-encode/src/impls/variant.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     error::{Error, ErrorKind, Kind},
-    EncodeAsFields, EncodeAsType,
+    EncodeAsFields, EncodeAsType, Field,
 };
 use codec::Encode;
 use scale_info::{PortableRegistry, TypeDef};
@@ -81,7 +81,8 @@ where
                     return Err(Error::new(ErrorKind::CannotFindVariant { name: self.name.to_string(), expected: type_id }));
                 };
                 v.index().encode_to(out);
-                self.fields.encode_as_fields_to(v.fields(), types, out)
+                let fields = v.fields().iter().map(|f| Field::new(f.ty().id(), f.name()));
+                self.fields.encode_as_fields_to(fields, types, out)
             }
             _ => Err(Error::new(ErrorKind::WrongShape {
                 actual: Kind::Str,

--- a/scale-encode/src/lib.rs
+++ b/scale-encode/src/lib.rs
@@ -151,11 +151,6 @@ pub use error::Error;
 pub use crate::impls::{Composite, Variant};
 pub use scale_info::PortableRegistry;
 
-// /// A description of a single field in a tuple or struct type. This is just a shorthand for a [`scale_info::Field`].
-// pub type PortableField = scale_info::Field<scale_info::form::PortableForm>;
-// /// A type ID used to represent tuple fields. This is a shorthand for a [`scale_info::interner::UntrackedSymbol`].
-// pub type PortableFieldId = scale_info::interner::UntrackedSymbol<std::any::TypeId>;
-
 #[cfg(feature = "derive")]
 pub use scale_encode_derive::EncodeAsType;
 

--- a/scale-encode/src/lib.rs
+++ b/scale-encode/src/lib.rs
@@ -21,9 +21,9 @@ exposes two traits:
 - An [`EncodeAsType`] trait which when implemented on some type, describes how it can be SCALE encoded
   with the help of a type ID and type registry describing the expected shape of the encoded bytes.
 - An [`EncodeAsFields`] trait which when implemented on some type, describes how it can be SCALE encoded
-  with the help of a slice of [`PortableField`]'s or [`PortableFieldId`]'s and type registry describing the
-  expected shape of the encoded bytes. This is generally only implemented for tuples and structs, since we
-  need a set of fields to map to the provided slices.
+  with the help of an iterator over [`Field`]s and a type registry describing the expected shape of the
+  encoded bytes. This is generally only implemented for tuples and structs, since we need a set of fields
+  to map to the provided iterator.
 
 Implementations for many built-in types are also provided for each trait, and the [`macro@EncodeAsType`]
 macro makes it easy to generate implementations for new structs and enums.
@@ -141,6 +141,8 @@ assert_encodes_to(
 
 mod impls;
 
+use std::borrow::Cow;
+
 pub mod error;
 
 pub use error::Error;
@@ -149,10 +151,10 @@ pub use error::Error;
 pub use crate::impls::{Composite, Variant};
 pub use scale_info::PortableRegistry;
 
-/// A description of a single field in a tuple or struct type. This is just a shorthand for a [`scale_info::Field`].
-pub type PortableField = scale_info::Field<scale_info::form::PortableForm>;
-/// A type ID used to represent tuple fields. This is a shorthand for a [`scale_info::interner::UntrackedSymbol`].
-pub type PortableFieldId = scale_info::interner::UntrackedSymbol<std::any::TypeId>;
+// /// A description of a single field in a tuple or struct type. This is just a shorthand for a [`scale_info::Field`].
+// pub type PortableField = scale_info::Field<scale_info::form::PortableForm>;
+// /// A type ID used to represent tuple fields. This is a shorthand for a [`scale_info::interner::UntrackedSymbol`].
+// pub type PortableFieldId = scale_info::interner::UntrackedSymbol<std::any::TypeId>;
 
 #[cfg(feature = "derive")]
 pub use scale_encode_derive::EncodeAsType;
@@ -183,50 +185,57 @@ pub trait EncodeAsType {
 /// tuple and struct types, and is automatically implemented via the [`macro@EncodeAsType`] macro.
 pub trait EncodeAsFields {
     /// Given some fields describing the shape of a type, attempt to encode to that shape.
-    fn encode_as_fields_to(
+    fn encode_as_fields_to<'a, I: Iterator<Item = Field<'a>> + Clone>(
         &self,
-        fields: &[PortableField],
+        fields: I,
         types: &PortableRegistry,
         out: &mut Vec<u8>,
     ) -> Result<(), Error>;
 
     /// This is a helper function which internally calls [`EncodeAsFields::encode_as_fields_to`]. Prefer to
     /// implement that instead.
-    fn encode_as_fields(
+    fn encode_as_fields<'a, I: Iterator<Item = Field<'a>> + Clone>(
         &self,
-        fields: &[PortableField],
+        fields: I,
         types: &PortableRegistry,
     ) -> Result<Vec<u8>, Error> {
         let mut out = Vec::new();
         self.encode_as_fields_to(fields, types, &mut out)?;
         Ok(out)
     }
+}
 
-    /// Given some field IDs describing the shape of a type, attempt to encode to that shape.
-    fn encode_as_field_ids_to(
-        &self,
-        field_ids: &[PortableFieldId],
-        types: &PortableRegistry,
-        out: &mut Vec<u8>,
-    ) -> Result<(), Error> {
-        // [TODO jsdw]: It would be good to use a more efficient data structure
-        // here to avoid allocating with smaller numbers of fields.
-        let fields: Vec<PortableField> = field_ids
-            .iter()
-            .map(|f| PortableField::new(None, *f, None, Vec::new()))
-            .collect();
-        self.encode_as_fields_to(&fields, types, out)
+/// A representation of a single field to be encoded via [`EncodeAsFields::encode_as_fields_to`].
+pub struct Field<'a> {
+    name: Option<Cow<'a, str>>,
+    id: u32,
+}
+
+impl<'a> Field<'a> {
+    /// Construct a new field with an ID and optional name.
+    pub fn new(id: u32, name: Option<impl Into<Cow<'a, str>>>) -> Self {
+        Field {
+            id,
+            name: name.map(Into::into),
+        }
     }
-
-    /// This is a helper function which internally calls [`EncodeAsFields::encode_as_field_ids_to`]. Prefer to
-    /// implement that instead.
-    fn encode_as_field_ids(
-        &self,
-        field_ids: &[PortableFieldId],
-        types: &PortableRegistry,
-    ) -> Result<Vec<u8>, Error> {
-        let mut out = Vec::new();
-        self.encode_as_field_ids_to(field_ids, types, &mut out)?;
-        Ok(out)
+    /// Create a new unnamed field.
+    pub fn unnamed(id: u32) -> Self {
+        Field { name: None, id }
+    }
+    /// Create a new named field.
+    pub fn named(id: u32, name: impl Into<Cow<'a, str>>) -> Self {
+        Field {
+            name: Some(name.into()),
+            id,
+        }
+    }
+    /// The field name, if any.
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+    /// The field ID.
+    pub fn id(&self) -> u32 {
+        self.id
     }
 }

--- a/scale-encode/src/lib.rs
+++ b/scale-encode/src/lib.rs
@@ -141,8 +141,6 @@ assert_encodes_to(
 
 mod impls;
 
-use std::borrow::Cow;
-
 pub mod error;
 
 pub use error::Error;
@@ -201,27 +199,25 @@ pub trait EncodeAsFields {
 }
 
 /// A representation of a single field to be encoded via [`EncodeAsFields::encode_as_fields_to`].
+#[derive(Debug, Clone)]
 pub struct Field<'a> {
-    name: Option<Cow<'a, str>>,
+    name: Option<&'a str>,
     id: u32,
 }
 
 impl<'a> Field<'a> {
     /// Construct a new field with an ID and optional name.
-    pub fn new(id: u32, name: Option<impl Into<Cow<'a, str>>>) -> Self {
-        Field {
-            id,
-            name: name.map(Into::into),
-        }
+    pub fn new(id: u32, name: Option<&'a str>) -> Self {
+        Field { id, name }
     }
     /// Create a new unnamed field.
     pub fn unnamed(id: u32) -> Self {
         Field { name: None, id }
     }
     /// Create a new named field.
-    pub fn named(id: u32, name: impl Into<Cow<'a, str>>) -> Self {
+    pub fn named(id: u32, name: &'a str) -> Self {
         Field {
-            name: Some(name.into()),
+            name: Some(name),
             id,
         }
     }

--- a/scale-encode/src/lib.rs
+++ b/scale-encode/src/lib.rs
@@ -178,7 +178,7 @@ pub trait EncodeAsType {
 /// tuple and struct types, and is automatically implemented via the [`macro@EncodeAsType`] macro.
 pub trait EncodeAsFields {
     /// Given some fields describing the shape of a type, attempt to encode to that shape.
-    fn encode_as_fields_to<'a, I: Iterator<Item = Field<'a>> + Clone>(
+    fn encode_as_fields_to<'a, I: FieldIter<'a>>(
         &self,
         fields: I,
         types: &PortableRegistry,
@@ -187,7 +187,7 @@ pub trait EncodeAsFields {
 
     /// This is a helper function which internally calls [`EncodeAsFields::encode_as_fields_to`]. Prefer to
     /// implement that instead.
-    fn encode_as_fields<'a, I: Iterator<Item = Field<'a>> + Clone>(
+    fn encode_as_fields<'a, I: FieldIter<'a>>(
         &self,
         fields: I,
         types: &PortableRegistry,
@@ -222,11 +222,15 @@ impl<'a> Field<'a> {
         }
     }
     /// The field name, if any.
-    pub fn name(&self) -> Option<&str> {
-        self.name.as_deref()
+    pub fn name(&self) -> Option<&'a str> {
+        self.name
     }
     /// The field ID.
     pub fn id(&self) -> u32 {
         self.id
     }
 }
+
+/// An iterator over a set of fields.
+pub trait FieldIter<'a>: Iterator<Item = Field<'a>> + Clone {}
+impl<'a, T> FieldIter<'a> for T where T: Iterator<Item = Field<'a>> + Clone {}

--- a/scale-encode/src/lib.rs
+++ b/scale-encode/src/lib.rs
@@ -199,7 +199,7 @@ pub trait EncodeAsFields {
 }
 
 /// A representation of a single field to be encoded via [`EncodeAsFields::encode_as_fields_to`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Field<'a> {
     name: Option<&'a str>,
     id: u32,


### PR DESCRIPTION
This allows for no-allocation encoding-as-fields when we have a set of names+IDs we want to encode but not necessarily in the form of a slive of scale_info field information. It also removes a couple of now-unnecessary methods from this interface.

The scale-decode PR to do the same is here: https://github.com/paritytech/scale-decode/pull/18

Also bumps `scale-info` and removes deprecated warnings.

Closes #6 