### PR TITLE
Add no-std compatibility

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,11 +86,6 @@ jobs:
           target: aarch64-unknown-none
           override: true
 
-      # Ensure cargo is run on the no_std target architecture. Specifying `--target` does not work here,
-      # because it automatically activates dev-dependencies, which are not no_std compatible.
-      - name: Rust create rust-toolchain.toml
-        run: echo -e "[toolchain]\ntargets = [\"aarch64-unknown-none\"]" > rust-toolchain.toml
-
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0
 
@@ -98,7 +93,9 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: check
-          args: --no-default-features --features bits,primitive-types,derive
+          # The aarch64-unknown-none doesn't support `std`, so this
+          # will fail if the crate is not no_std compatible.
+          args: --no-default-features --target aarch64-unknown-none --features bits,primitive-types,derive
 
   fmt:
     name: Cargo fmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: check
-          args: --no-default-features --features bits,primitive-types
+          args: --no-default-features --features bits,primitive-types,derive
 
   fmt:
     name: Cargo fmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,14 +72,19 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      # Set default target aarch64-unknown-none because it doesn't support `std`.
-      # So this will fail if the crate is not no_std compatible.
-      - name: Rust create rust-toolchain.toml
-        run: echo -e "[toolchain]\nchannel = \"nightly\"\ntargets = [\"aarch64-unknown-none\"]\nprofile = \"minimal\"" > rust-toolchain.toml
-
-      # no_std version currently needs nightly due to error_in_core feature
+        # no_std version currently needs nightly due to error_in_core feature
       - name: Install Rust nightly toolchain
-        run: rustup show
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          target: aarch64-unknown-none
+          override: true
+
+      # Ensure cargo is run on the no_std target architecture. Specifying `--target` does not work here,
+      # because it automatically actives dev-dependencies, which are not no-std compatible.
+      - name: Rust create rust-toolchain.toml
+        run: echo -e "[toolchain]\nchannel = \"nightly\"\ntargets = [\"aarch64-unknown-none\"]" > rust-toolchain.toml
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,6 +71,34 @@ jobs:
           # we run tests using BitVec<u64,_> which doesn't.
           args: --all-features --target wasm32-unknown-unknown
 
+
+  no_std:
+    name: Check no_std build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      # no_std version currently needs nightly due to error_in_core feature
+      - name: Install Rust nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          target: aarch64-unknown-none
+          override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.3.0
+
+      - name: Check no_std build
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          # The aarch64-unknown-none doesn't support `std`, so this
+          # will fail if the crate is not no_std compatible.
+          args: --no-default-features --target aarch64-unknown-none --features bits,derive,primitive-types
+
   fmt:
     name: Cargo fmt
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,12 @@ jobs:
           command: check
           args: --all-targets --all-features --workspace
 
+      - name: Check no features
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+          args: --all-targets --no-default-features --workspace
+
   wasm:
     name: Check WASM compatibility
     runs-on: ubuntu-latest
@@ -72,19 +78,18 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-        # no_std version currently needs nightly due to error_in_core feature
-      - name: Install Rust nightly toolchain
+      - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           target: aarch64-unknown-none
           override: true
 
       # Ensure cargo is run on the no_std target architecture. Specifying `--target` does not work here,
       # because it automatically activates dev-dependencies, which are not no_std compatible.
       - name: Rust create rust-toolchain.toml
-        run: echo -e "[toolchain]\nchannel = \"nightly\"\ntargets = [\"aarch64-unknown-none\"]" > rust-toolchain.toml
+        run: echo -e "[toolchain]\ntargets = [\"aarch64-unknown-none\"]" > rust-toolchain.toml
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -164,6 +164,12 @@ jobs:
           command: test
           args: --all-targets --workspace
 
+      - name: Cargo test no_std
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+          args: --all-targets --workspace --no-default-features --features bits,primitive-types
+
       - name: Cargo test docs
         uses: actions-rs/cargo@v1.0.3
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,12 +39,6 @@ jobs:
           command: check
           args: --all-targets --all-features --workspace
 
-      - name: Check no features
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: check
-          args: --all-targets --no-default-features --workspace
-
   wasm:
     name: Check WASM compatibility
     runs-on: ubuntu-latest
@@ -71,7 +65,6 @@ jobs:
           # we run tests using BitVec<u64,_> which doesn't.
           args: --all-features --target wasm32-unknown-unknown
 
-
   no_std:
     name: Check no_std build
     runs-on: ubuntu-latest
@@ -97,7 +90,7 @@ jobs:
           command: check
           # The aarch64-unknown-none doesn't support `std`, so this
           # will fail if the crate is not no_std compatible.
-          args: --no-default-features --target aarch64-unknown-none --features bits,derive,primitive-types
+          args: +nightly --no-default-features --features bits,primitive-types
 
   fmt:
     name: Cargo fmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,8 +72,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      # Set default target arch to ensure the toolchain for no-std
-      # environments is used.
+      # Set default target aarch64-unknown-none because it doesn't support `std`.
+      # So this will fail if the crate is not no_std compatible.
       - name: Rust create rust-toolchain.toml
         run: echo -e "[toolchain]\nchannel = \"nightly\"\ntargets = [\"aarch64-unknown-none\"]\nprofile = \"minimal\"" > rust-toolchain.toml
 
@@ -88,8 +88,6 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: check
-          # The aarch64-unknown-none doesn't support `std`, so this
-          # will fail if the crate is not no_std compatible.
           args: --no-default-features --features bits,primitive-types
 
   fmt:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,7 @@ jobs:
           override: true
 
       # Ensure cargo is run on the no_std target architecture. Specifying `--target` does not work here,
-      # because it automatically actives dev-dependencies, which are not no-std compatible.
+      # because it automatically activates dev-dependencies, which are not no_std compatible.
       - name: Rust create rust-toolchain.toml
         run: echo -e "[toolchain]\nchannel = \"nightly\"\ntargets = [\"aarch64-unknown-none\"]" > rust-toolchain.toml
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,14 +72,14 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
+      # Set default target arch to ensure the toolchain for no-std
+      # environments is used.
+      - name: Rust create rust-toolchain.toml
+        run: echo -e "[toolchain]\nchannel = \"nightly\"\ntargets = [\"aarch64-unknown-none\"]\nprofile = \"minimal\"" > rust-toolchain.toml
+
       # no_std version currently needs nightly due to error_in_core feature
       - name: Install Rust nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          target: aarch64-unknown-none
-          override: true
+        run: rustup show
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0
@@ -90,7 +90,7 @@ jobs:
           command: check
           # The aarch64-unknown-none doesn't support `std`, so this
           # will fail if the crate is not no_std compatible.
-          args: +nightly --no-default-features --features bits,primitive-types
+          args: --no-default-features --features bits,primitive-types
 
   fmt:
     name: Cargo fmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 members = [
     "scale-encode",
-    "scale-encode-derive"
+    "scale-encode-derive",
+    "testing/no_std",
 ]
 
 [workspace.package]

--- a/scale-encode-derive/src/lib.rs
+++ b/scale-encode-derive/src/lib.rs
@@ -81,7 +81,7 @@ fn generate_enum_impl(
                 // long variable names to prevent conflict with struct field names:
                 __encode_as_type_type_id: u32,
                 __encode_as_type_types: &#path_to_scale_encode::PortableRegistry,
-                __encode_as_type_out: &mut Vec<u8>
+                __encode_as_type_out: &mut #path_to_scale_encode::Vec<u8>
             ) -> Result<(), #path_to_scale_encode::Error> {
                 match self {
                     #( #match_arms, )*
@@ -113,7 +113,7 @@ fn generate_struct_impl(
                 // long variable names to prevent conflict with struct field names:
                 __encode_as_type_type_id: u32,
                 __encode_as_type_types: &#path_to_scale_encode::PortableRegistry,
-                __encode_as_type_out: &mut Vec<u8>
+                __encode_as_type_out: &mut #path_to_scale_encode::Vec<u8>
             ) -> Result<(), #path_to_scale_encode::Error> {
                 let #path_to_type #matcher = self;
                 #composite.encode_as_type_to(
@@ -129,7 +129,7 @@ fn generate_struct_impl(
                 // long variable names to prevent conflict with struct field names:
                 __encode_as_type_fields: &mut dyn #path_to_scale_encode::FieldIter<'_>,
                 __encode_as_type_types: &#path_to_scale_encode::PortableRegistry,
-                __encode_as_type_out: &mut Vec<u8>
+                __encode_as_type_out: &mut #path_to_scale_encode::Vec<u8>
             ) -> Result<(), #path_to_scale_encode::Error> {
                 let #path_to_type #matcher = self;
                 #composite.encode_as_fields_to(
@@ -193,15 +193,13 @@ fn fields_to_matcher_and_composite(
             )
         }
         syn::Fields::Unnamed(fields) => {
-            let field_idents: Vec<syn::Ident> = fields
+            let field_idents = fields
                 .unnamed
                 .iter()
                 .enumerate()
-                .map(|(idx, _)| format_ident!("_{idx}"))
-                .collect();
-            let match_body = field_idents.iter().map(|i| quote!(#i));
+                .map(|(idx, _)| format_ident!("_{idx}"));
+            let match_body = field_idents.clone().map(|i| quote!(#i));
             let tuple_body = field_idents
-                .iter()
                 .map(|i| quote!((None as Option<&'static str>, #i as &dyn #path_to_scale_encode::EncodeAsType)));
 
             (

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -30,7 +30,7 @@ bits = ["dep:scale-bits"]
 
 [dependencies]
 scale-info = { version = "2.7.0",  default-features = false, features = ["bit-vec"] }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99.5" }
 scale-bits = { version = "0.4.0", default-features = false, features = ["scale-info"], optional = true }
 scale-encode-derive = { workspace = true, optional = true }
@@ -41,7 +41,7 @@ smallvec = "1.10.0"
 bitvec = "1.0.1"
 scale-info = { version = "2.3.0", features = ["bit-vec", "derive"] }
 scale-encode-derive = { workspace = true }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "bit-vec"] }
 trybuild = "1.0.72"
 # enable scale-info feature for testing:
 primitive-types = { version = "0.12.0", default-features = false, features = ["scale-info"] }

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -29,7 +29,7 @@ primitive-types = ["dep:primitive-types"]
 bits = ["dep:scale-bits"]
 
 [dependencies]
-scale-info = { version = "2.7.0",  default-features = false, features = ["bit-vec"] }
+scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 scale-bits = { version = "0.4.0", default-features = false, features = ["scale-info"], optional = true }
 scale-encode-derive = { workspace = true, optional = true }

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -14,22 +14,25 @@ keywords.workspace = true
 include.workspace = true
 
 [features]
-default = ["derive", "primitive-types", "bits"]
+default = ["std", "derive", "primitive-types", "bits"]
 
-# Include the derive proc macro
+# Activates std feature.
+std = ["scale-info/std"]
+
+# Include the derive proc macro.
 derive = ["dep:scale-encode-derive"]
 
-# impls for key primitive-types
+# impls for key primitive-types.
 primitive-types = ["dep:primitive-types"]
 
 # impls for Bits.
 bits = ["dep:scale-bits"]
 
 [dependencies]
-scale-info = { version = "2.7.0", features = ["bit-vec"] }
-thiserror = "1.0.37"
+scale-info = { version = "2.7.0",  default-features = false, features = ["bit-vec"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
-scale-bits = { version = "0.3.0", default-features = false, features = ["scale-info"], optional = true }
+derive_more = { version = "0.99.5" }
+scale-bits = { default-features = false, features = ["scale-info"], git = "https://github.com/haerdib/scale-bits.git", branch = "bh/no-std", optional = true }
 scale-encode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -37,8 +37,8 @@ primitive-types = { version = "0.12.0", optional = true, default-features = fals
 smallvec = "1.10.0"
 
 [dev-dependencies]
-bitvec = "1.0.1"
-scale-info = { version = "2.3.0", features = ["bit-vec", "derive"] }
+bitvec = { version = "1.0.1", default-features = false }
+scale-info = { version = "2.3.0", features = ["bit-vec", "derive"], default-features = false }
 scale-encode-derive = { workspace = true }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "bit-vec"] }
 trybuild = "1.0.72"

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -31,7 +31,6 @@ bits = ["dep:scale-bits"]
 [dependencies]
 scale-info = { version = "2.7.0",  default-features = false, features = ["bit-vec"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-derive_more = { version = "0.99.5" }
 scale-bits = { version = "0.4.0", default-features = false, features = ["scale-info"], optional = true }
 scale-encode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -32,7 +32,7 @@ bits = ["dep:scale-bits"]
 scale-info = { version = "2.7.0",  default-features = false, features = ["bit-vec"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99.5" }
-scale-bits = { default-features = false, features = ["scale-info"], git = "https://github.com/haerdib/scale-bits.git", branch = "bh/no-std", optional = true }
+scale-bits = { version = "0.4.0", default-features = false, features = ["scale-info"], optional = true }
 scale-encode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -19,8 +19,8 @@ default = ["std", "derive", "primitive-types", "bits"]
 # Activates std feature.
 std = ["scale-info/std"]
 
-# Include the derive proc macro.
-derive = ["dep:scale-encode-derive"]
+# Include the derive proc macro. This is only availbale in std.
+derive = ["dep:scale-encode-derive", "std"]
 
 # impls for key primitive-types.
 primitive-types = ["dep:primitive-types"]

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -19,8 +19,8 @@ default = ["std", "derive", "primitive-types", "bits"]
 # Activates std feature.
 std = ["scale-info/std"]
 
-# Include the derive proc macro. This is only available in std.
-derive = ["dep:scale-encode-derive", "std"]
+# Include the derive proc macro.
+derive = ["dep:scale-encode-derive"]
 
 # impls for key primitive-types.
 primitive-types = ["dep:primitive-types"]

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -19,7 +19,7 @@ default = ["std", "derive", "primitive-types", "bits"]
 # Activates std feature.
 std = ["scale-info/std"]
 
-# Include the derive proc macro. This is only availbale in std.
+# Include the derive proc macro. This is only available in std.
 derive = ["dep:scale-encode-derive", "std"]
 
 # impls for key primitive-types.

--- a/scale-encode/src/error/context.rs
+++ b/scale-encode/src/error/context.rs
@@ -16,7 +16,7 @@
 //! This module provides a [`Context`] type, which tracks the path
 //! that we're attempting to encode to aid in error reporting.
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, vec::Vec};
 
 /// A cheaply clonable opaque context which allows us to track the current
 /// location into a type that we're trying to encode, to aid in
@@ -55,8 +55,8 @@ impl<'a> Path<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for Path<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<'a> core::fmt::Display for Path<'a> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         for (idx, loc) in self.0.iter().enumerate() {
             if idx != 0 {
                 f.write_str(".")?;

--- a/scale-encode/src/error/mod.rs
+++ b/scale-encode/src/error/mod.rs
@@ -18,12 +18,11 @@ mod context;
 
 use alloc::{borrow::Cow, boxed::Box, string::String};
 use core::fmt::Display;
-use derive_more::From;
 
 pub use context::{Context, Location};
 
 /// An error produced while attempting to encode some type.
-#[derive(Debug, From)]
+#[derive(Debug)]
 pub struct Error {
     context: Context,
     kind: ErrorKind,
@@ -87,7 +86,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let path = self.context.path();
         let kind = &self.kind;
-        write!(f, "Error at {path}: {kind:?}")
+        write!(f, "Error at {path}: {kind}")
     }
 }
 
@@ -139,6 +138,12 @@ impl From<CustomError> for ErrorKind {
     }
 }
 
+impl Display for ErrorKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
 #[cfg(feature = "std")]
 type CustomError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -147,7 +152,7 @@ type CustomError = Box<dyn core::fmt::Debug + Send + Sync + 'static>;
 
 /// The kind of type that we're trying to encode.
 #[allow(missing_docs)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, derive_more::Display)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Kind {
     Struct,
     Tuple,
@@ -160,13 +165,25 @@ pub enum Kind {
     Number,
 }
 
+impl Display for Kind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
 
-    #[derive(Debug, derive_more::Display)]
+    #[derive(Debug)]
     enum MyError {
         Foo,
+    }
+
+    impl Display for MyError {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(f, "{self:?}")
+        }
     }
 
     #[cfg(feature = "std")]

--- a/scale-encode/src/error/mod.rs
+++ b/scale-encode/src/error/mod.rs
@@ -16,8 +16,6 @@
 //! An error that is emitted whenever some encoding fails.
 mod context;
 
-pub use context::{Context, Location};
-
 use alloc::{borrow::Cow, boxed::Box, string::String};
 use core::fmt::Display;
 use derive_more::From;
@@ -28,6 +26,8 @@ use derive_more::From;
 use core::error::Error as StdError;
 #[cfg(feature = "std")]
 use std::error::Error as StdError;
+
+pub use context::{Context, Location};
 
 /// An error produced while attempting to encode some type.
 #[derive(Debug, From)]

--- a/scale-encode/src/error/mod.rs
+++ b/scale-encode/src/error/mod.rs
@@ -140,7 +140,36 @@ impl From<CustomError> for ErrorKind {
 
 impl Display for ErrorKind {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{self:?}")
+        match self {
+            ErrorKind::TypeNotFound(id) => write!(f, "Cannot find type with ID {id}"),
+            ErrorKind::WrongShape { actual, expected } => {
+                write!(f, "Cannot encode {actual:?} into type with ID {expected}")
+            }
+            ErrorKind::WrongLength {
+                actual_len,
+                expected_len,
+            } => {
+                write!(f, "Cannot encode to type; expected length {expected_len} but got length {actual_len}")
+            }
+            ErrorKind::NumberOutOfRange { value, expected } => {
+                write!(
+                    f,
+                    "Number {value} is out of range for target type {expected}"
+                )
+            }
+            ErrorKind::CannotFindVariant { name, expected } => {
+                write!(
+                    f,
+                    "Variant {name} does not exist on type with ID {expected}"
+                )
+            }
+            ErrorKind::CannotFindField { name } => {
+                write!(f, "Field {name} does not exist in our source struct")
+            }
+            ErrorKind::Custom(custom_error) => {
+                write!(f, "Custom error: {custom_error:?}")
+            }
+        }
     }
 }
 
@@ -163,12 +192,6 @@ pub enum Kind {
     Char,
     Str,
     Number,
-}
-
-impl Display for Kind {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{self:?}")
-    }
 }
 
 #[cfg(test)]

--- a/scale-encode/src/error/mod.rs
+++ b/scale-encode/src/error/mod.rs
@@ -172,7 +172,7 @@ mod test {
     #[cfg(feature = "std")]
     impl std::error::Error for MyError {}
 
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(not(feature = "std"))]
     impl Into<CustomError> for MyError {
         fn into(self) -> CustomError {
             Box::new(self)

--- a/scale-encode/src/impls/bits.rs
+++ b/scale-encode/src/impls/bits.rs
@@ -17,6 +17,7 @@ use crate::{
     error::{Error, ErrorKind, Kind},
     EncodeAsType,
 };
+use alloc::vec::Vec;
 use scale_info::TypeDef;
 
 impl EncodeAsType for scale_bits::Bits {

--- a/scale-encode/src/impls/composite.rs
+++ b/scale-encode/src/impls/composite.rs
@@ -17,13 +17,9 @@ use crate::{
     error::{Error, ErrorKind, Kind, Location},
     EncodeAsFields, EncodeAsType, Field, FieldIter,
 };
+use alloc::collections::BTreeMap;
 use alloc::{string::ToString, vec::Vec};
 use scale_info::{PortableRegistry, TypeDef};
-
-#[cfg(not(feature = "std"))]
-use alloc::collections::BTreeMap as MapType;
-#[cfg(feature = "std")]
-use std::collections::HashMap as MapType;
 
 /// This type represents named or unnamed composite values, and can be used
 /// to help generate `EncodeAsType` impls. It's primarily used by the exported
@@ -161,7 +157,7 @@ where
             // then encode to the target type by matching the names. If fields are
             // named, we don't even mind if the number of fields doesn't line up;
             // we just ignore any fields we provided that aren't needed.
-            let source_fields_by_name: MapType<&str, &dyn EncodeAsType> = vals_iter
+            let source_fields_by_name: BTreeMap<&str, &dyn EncodeAsType> = vals_iter
                 .map(|(name, val)| (name.unwrap_or(""), val))
                 .collect();
 

--- a/scale-encode/src/impls/composite.rs
+++ b/scale-encode/src/impls/composite.rs
@@ -17,8 +17,13 @@ use crate::{
     error::{Error, ErrorKind, Kind, Location},
     EncodeAsFields, EncodeAsType, Field, FieldIter,
 };
+use alloc::{string::ToString, vec::Vec};
 use scale_info::{PortableRegistry, TypeDef};
-use std::collections::HashMap;
+
+#[cfg(not(feature = "std"))]
+use alloc::collections::BTreeMap as MapType;
+#[cfg(feature = "std")]
+use std::collection::HashMap as MapType;
 
 /// This type represents named or unnamed composite values, and can be used
 /// to help generate `EncodeAsType` impls. It's primarily used by the exported
@@ -156,7 +161,7 @@ where
             // then encode to the target type by matching the names. If fields are
             // named, we don't even mind if the number of fields doesn't line up;
             // we just ignore any fields we provided that aren't needed.
-            let source_fields_by_name: HashMap<&str, &dyn EncodeAsType> = vals_iter
+            let source_fields_by_name: MapType<&str, &dyn EncodeAsType> = vals_iter
                 .map(|(name, val)| (name.unwrap_or(""), val))
                 .collect();
 

--- a/scale-encode/src/impls/composite.rs
+++ b/scale-encode/src/impls/composite.rs
@@ -23,7 +23,7 @@ use scale_info::{PortableRegistry, TypeDef};
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap as MapType;
 #[cfg(feature = "std")]
-use std::collection::HashMap as MapType;
+use std::collections::HashMap as MapType;
 
 /// This type represents named or unnamed composite values, and can be used
 /// to help generate `EncodeAsType` impls. It's primarily used by the exported

--- a/scale-encode/src/impls/mod.rs
+++ b/scale-encode/src/impls/mod.rs
@@ -538,8 +538,8 @@ mod test {
     use super::*;
     use crate::{EncodeAsFields, Field};
     use codec::Decode;
+    use core::fmt::Debug;
     use scale_info::TypeInfo;
-    use std::fmt::Debug;
 
     /// Given a type definition, return type ID and registry representing it.
     fn make_type<T: TypeInfo + 'static>() -> (u32, PortableRegistry) {
@@ -696,7 +696,7 @@ mod test {
         assert_encodes_like_codec(-1234);
         assert_encodes_like_codec(100_000_000_000_000u128);
         assert_encodes_like_codec(());
-        assert_encodes_like_codec(std::marker::PhantomData::<()>);
+        assert_encodes_like_codec(core::marker::PhantomData::<()>);
         assert_encodes_like_codec([1, 2, 3, 4, 5]);
         assert_encodes_like_codec([1u8, 2, 3, 4, 5]);
         assert_encodes_like_codec(vec![1, 2, 3, 4, 5]);
@@ -711,7 +711,7 @@ mod test {
         // These don't impl TypeInfo so we have to provide the target type to encode to & compare with:
         assert_value_roundtrips_to(Arc::new("hi"), "hi".to_string());
         assert_value_roundtrips_to(Rc::new("hi"), "hi".to_string());
-        // encodes_like_codec(std::time::Duration::from_millis(123456));
+        // encodes_like_codec(core::time::Duration::from_millis(123456));
     }
 
     #[test]

--- a/scale-encode/src/impls/mod.rs
+++ b/scale-encode/src/impls/mod.rs
@@ -953,7 +953,7 @@ mod test {
 
     #[test]
     fn hxxx_types_roundtrip_ok() {
-        use super::primitive_types::{H128, H160, H256, H384, H512, H768};
+        use ::primitive_types::{H128, H160, H256, H384, H512, H768};
 
         // Check that Hxxx types roundtirp to themselves or to byte sequences
         fn test_hxxx(bytes: impl IntoIterator<Item = u8> + Clone) {

--- a/scale-encode/src/impls/mod.rs
+++ b/scale-encode/src/impls/mod.rs
@@ -25,20 +25,30 @@ mod variant;
 pub use composite::Composite;
 pub use variant::Variant;
 
-use crate::error::{Error, ErrorKind, Kind};
-use crate::{EncodeAsFields, EncodeAsType, FieldIter};
-use codec::{Compact, Encode};
-use core::num::{
-    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
-    NonZeroU32, NonZeroU64, NonZeroU8,
+use crate::{
+    error::{Error, ErrorKind, Kind},
+    EncodeAsFields, EncodeAsType, FieldIter,
 };
-use core::ops::{Range, RangeInclusive};
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque},
+    rc::Rc,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
+use codec::{Compact, Encode};
+use core::{
+    marker::PhantomData,
+    num::{
+        NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU128, NonZeroU16,
+        NonZeroU32, NonZeroU64, NonZeroU8,
+    },
+    ops::{Range, RangeInclusive},
+    time::Duration,
+};
 use scale_info::{PortableRegistry, TypeDef, TypeDefPrimitive};
-use std::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
-use std::marker::PhantomData;
-use std::rc::Rc;
-use std::sync::Arc;
-use std::time::Duration;
 
 impl EncodeAsType for bool {
     fn encode_as_type_to(
@@ -102,7 +112,7 @@ where
     }
 }
 
-impl<'a, T> EncodeAsType for std::borrow::Cow<'a, T>
+impl<'a, T> EncodeAsType for alloc::borrow::Cow<'a, T>
 where
     T: 'a + EncodeAsType + ToOwned + ?Sized,
 {
@@ -943,7 +953,7 @@ mod test {
 
     #[test]
     fn hxxx_types_roundtrip_ok() {
-        use ::primitive_types::{H128, H160, H256, H384, H512, H768};
+        use super::primitive_types::{H128, H160, H256, H384, H512, H768};
 
         // Check that Hxxx types roundtirp to themselves or to byte sequences
         fn test_hxxx(bytes: impl IntoIterator<Item = u8> + Clone) {

--- a/scale-encode/src/impls/mod.rs
+++ b/scale-encode/src/impls/mod.rs
@@ -537,6 +537,7 @@ where
 mod test {
     use super::*;
     use crate::{EncodeAsFields, Field};
+    use alloc::vec;
     use codec::Decode;
     use core::fmt::Debug;
     use scale_info::TypeInfo;

--- a/scale-encode/src/impls/primitive_types.rs
+++ b/scale-encode/src/impls/primitive_types.rs
@@ -15,7 +15,7 @@
 
 use crate::{error::Error, EncodeAsType};
 use alloc::vec::Vec;
-pub use primitive_types::{H128, H160, H256, H384, H512, H768};
+use primitive_types::{H128, H160, H256, H384, H512, H768};
 
 macro_rules! impl_encode {
     ($($ty:ty),*) => {$(

--- a/scale-encode/src/impls/primitive_types.rs
+++ b/scale-encode/src/impls/primitive_types.rs
@@ -14,7 +14,8 @@
 // limitations under the License.
 
 use crate::{error::Error, EncodeAsType};
-use primitive_types::{H128, H160, H256, H384, H512, H768};
+use alloc::vec::Vec;
+pub use primitive_types::{H128, H160, H256, H384, H512, H768};
 
 macro_rules! impl_encode {
     ($($ty:ty),*) => {$(

--- a/scale-encode/src/impls/variant.rs
+++ b/scale-encode/src/impls/variant.rs
@@ -17,6 +17,7 @@ use crate::{
     error::{Error, ErrorKind, Kind},
     EncodeAsFields, EncodeAsType, Field,
 };
+use alloc::{string::ToString, vec::Vec};
 use codec::Encode;
 use scale_info::{PortableRegistry, TypeDef};
 

--- a/scale-encode/src/lib.rs
+++ b/scale-encode/src/lib.rs
@@ -147,7 +147,10 @@ mod impls;
 
 pub mod error;
 
+// This is exported for generated derive code to use, to be compatible with std or no-std as needed.
+#[doc(hidden)]
 pub use alloc::vec::Vec;
+
 pub use error::Error;
 
 // Useful types to help implement EncodeAsType/Fields with:

--- a/scale-encode/src/lib.rs
+++ b/scale-encode/src/lib.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg_attr(not(feature = "std"), no_std, feature(error_in_core))]
+
 /*!
 `parity-scale-codec` provides an `Encode` trait which allows types to SCALE encode themselves based on their shape.
 This crate builds on this, and allows types to encode themselves based on [`scale_info`] type information. It
@@ -149,6 +151,10 @@ pub use error::Error;
 pub use crate::impls::{Composite, Variant};
 pub use scale_info::PortableRegistry;
 
+extern crate alloc;
+
+use alloc::vec::Vec;
+
 /// This trait signals that some static type can possibly be SCALE encoded given some
 /// `type_id` and [`PortableRegistry`] which dictates the expected encoding.
 pub trait EncodeAsType {
@@ -232,18 +238,6 @@ impl<'a> Field<'a> {
 pub trait FieldIter<'a>: Iterator<Item = Field<'a>> {}
 impl<'a, T> FieldIter<'a> for T where T: Iterator<Item = Field<'a>> {}
 
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    // Confirm object safety of EncodeAsFields; we want this.
-    // (doesn't really need to run; compile time only.)
-    #[test]
-    fn is_object_safe() {
-        fn _foo(_input: Box<dyn EncodeAsFields>) {}
-    }
-}
-
 /// The `EncodeAsType` derive macro can be used to implement `EncodeAsType`
 /// on structs and enums whose fields all implement `EncodeAsType`.
 ///
@@ -313,3 +307,16 @@ mod test {
 ///   behaviour and provide your own trait bounds instead using this option.
 #[cfg(feature = "derive")]
 pub use scale_encode_derive::EncodeAsType;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use alloc::boxed::Box;
+
+    // Confirm object safety of EncodeAsFields; we want this.
+    // (doesn't really need to run; compile time only.)
+    #[test]
+    fn is_object_safe() {
+        fn _foo(_input: Box<dyn EncodeAsFields>) {}
+    }
+}

--- a/scale-encode/src/lib.rs
+++ b/scale-encode/src/lib.rs
@@ -141,6 +141,8 @@ assert_encodes_to(
 */
 #![deny(missing_docs)]
 
+extern crate alloc;
+
 mod impls;
 
 pub mod error;
@@ -151,7 +153,11 @@ pub use error::Error;
 pub use crate::impls::{Composite, Variant};
 pub use scale_info::PortableRegistry;
 
-extern crate alloc;
+/// Re-exports of external crates.
+pub mod ext {
+    #[cfg(feature = "primitive-types")]
+    pub use primitive_types;
+}
 
 use alloc::vec::Vec;
 

--- a/scale-encode/src/lib.rs
+++ b/scale-encode/src/lib.rs
@@ -147,6 +147,7 @@ mod impls;
 
 pub mod error;
 
+pub use alloc::vec::Vec;
 pub use error::Error;
 
 // Useful types to help implement EncodeAsType/Fields with:
@@ -158,8 +159,6 @@ pub mod ext {
     #[cfg(feature = "primitive-types")]
     pub use primitive_types;
 }
-
-use alloc::vec::Vec;
 
 /// This trait signals that some static type can possibly be SCALE encoded given some
 /// `type_id` and [`PortableRegistry`] which dictates the expected encoding.

--- a/scale-encode/src/lib.rs
+++ b/scale-encode/src/lib.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "std"), no_std, feature(error_in_core))]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 /*!
 `parity-scale-codec` provides an `Encode` trait which allows types to SCALE encode themselves based on their shape.

--- a/scale-encode/tests/macros/pass_derive_generics.rs
+++ b/scale-encode/tests/macros/pass_derive_generics.rs
@@ -21,20 +21,20 @@ struct NotEncodeAsType;
 #[derive(EncodeAsType)]
 enum Bar<T, U, V> {
     Wibble(bool, T, U, V),
-    Wobble
+    Wobble,
 }
 
 // This impls EncodeAsType ok; we set no default trait bounds.
 #[derive(EncodeAsType)]
 #[encode_as_type(trait_bounds = "")]
 enum NoTraitBounds<T> {
-    Wibble(std::marker::PhantomData<T>),
+    Wibble(core::marker::PhantomData<T>),
 }
 
 // Structs (and const bounds) impl EncodeAsType OK.
 #[derive(EncodeAsType)]
 struct MyStruct<const V: usize, Bar: Clone + PartialEq> {
-    array: [Bar; V]
+    array: [Bar; V],
 }
 
 fn can_encode_as_type<T: EncodeAsType>() {}

--- a/testing/no_std/Cargo.toml
+++ b/testing/no_std/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "test-no-std"
+description = "Testing no_std build of scale-encode"
+readme = "README.md"
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+include.workspace = true
+
+[dependencies]
+scale-encode = { path = "../../scale-encode", default-features = false, features = ["primitive-types", "derive", "bits"] }

--- a/testing/no_std/README.md
+++ b/testing/no_std/README.md
@@ -1,0 +1,1 @@
+test no_std build of scale-encode and scale-encode-derive

--- a/testing/no_std/src/lib.rs
+++ b/testing/no_std/src/lib.rs
@@ -1,0 +1,29 @@
+#![no_std]
+extern crate alloc;
+
+use alloc::string::String;
+use scale_encode::EncodeAsType;
+
+struct NotEncodeAsType;
+
+// Enums with generic params can impl EncodeAsType.
+#[derive(EncodeAsType)]
+enum Bar<T, U, V> {
+    Wibble(bool, T, U, V),
+    Wobble,
+}
+
+// This impls EncodeAsType ok; we set no default trait bounds.
+#[derive(EncodeAsType)]
+#[encode_as_type(trait_bounds = "")]
+enum NoTraitBounds<T> {
+    Wibble(core::marker::PhantomData<T>),
+}
+
+// Structs (and const bounds) impl EncodeAsType OK.
+#[derive(EncodeAsType)]
+struct MyStruct<const V: usize, Bar: Clone + PartialEq> {
+    array: [Bar; V],
+}
+
+fn can_encode_as_type<T: EncodeAsType>() {}

--- a/testing/no_std/src/lib.rs
+++ b/testing/no_std/src/lib.rs
@@ -1,14 +1,13 @@
 #![no_std]
 extern crate alloc;
 
-use alloc::string::String;
 use scale_encode::EncodeAsType;
 
-struct NotEncodeAsType;
+pub struct NotEncodeAsType;
 
 // Enums with generic params can impl EncodeAsType.
 #[derive(EncodeAsType)]
-enum Bar<T, U, V> {
+pub enum Bar<T, U, V> {
     Wibble(bool, T, U, V),
     Wobble,
 }
@@ -16,14 +15,14 @@ enum Bar<T, U, V> {
 // This impls EncodeAsType ok; we set no default trait bounds.
 #[derive(EncodeAsType)]
 #[encode_as_type(trait_bounds = "")]
-enum NoTraitBounds<T> {
+pub enum NoTraitBounds<T> {
     Wibble(core::marker::PhantomData<T>),
 }
 
 // Structs (and const bounds) impl EncodeAsType OK.
 #[derive(EncodeAsType)]
-struct MyStruct<const V: usize, Bar: Clone + PartialEq> {
+pub struct MyStruct<const V: usize, Bar: Clone + PartialEq> {
     array: [Bar; V],
 }
 
-fn can_encode_as_type<T: EncodeAsType>() {}
+pub fn can_encode_as_type<T: EncodeAsType>() {}


### PR DESCRIPTION
Add no-std feature gate:
- `no_std` is activated in case of deactivated `std` feature
- removes `thiserror` because it's not no-std compatible
- removes `full` feature from codec import (deprecated)

CI changes:
- Adds a `Check no_std build`
- Adds extra crate `testing/no_std` to ensure scale-encode-derive is no_std by CI