### PR TITLE
Prep to release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [v0.4.0] - 2023-07-11
+
+- Add support for `no_std` (+alloc) builds ([#11](https://github.com/paritytech/scale-encode/pull/11)). Thankyou @haerdib!
+
 ## [v0.3.0] - 2023-05-31
 
 - Remove the generic iterator from `EncodeAsFields` and ensure that it's object safe. Use a `&mut dyn` iterator instead.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -16,5 +16,5 @@ keywords = ["parity", "scale", "encoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [workspace.dependencies]
-scale-encode = { version = "0.3.0", path = "scale-encode" }
-scale-encode-derive = { version = "0.3.0", path = "scale-encode-derive" }
+scale-encode = { version = "0.4.0", path = "scale-encode" }
+scale-encode-derive = { version = "0.4.0", path = "scale-encode-derive" }


### PR DESCRIPTION
- Add support for `no_std` (+alloc) builds ([#11](https://github.com/paritytech/scale-encode/pull/11)). Thankyou @haerdib!