### PR TITLE
Improve error handling + consistency when no_std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [v0.5.0] - 2023-07-28
+
+- Improve custom error handling: custom errors now require `Debug + Display` on `no_std` or `Error` on `std`.
+  `Error::custom()` now accepts anything implementing these traits rather than depending on `Into<Error>`.
+
 ## [v0.4.0] - 2023-07-11
 
 - Add support for `no_std` (+alloc) builds ([#11](https://github.com/paritytech/scale-encode/pull/11)). Thankyou @haerdib!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -16,5 +16,5 @@ keywords = ["parity", "scale", "encoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [workspace.dependencies]
-scale-encode = { version = "0.4.0", path = "scale-encode" }
-scale-encode-derive = { version = "0.4.0", path = "scale-encode-derive" }
+scale-encode = { version = "0.5.0", path = "scale-encode" }
+scale-encode-derive = { version = "0.5.0", path = "scale-encode-derive" }

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -35,6 +35,7 @@ scale-bits = { version = "0.4.0", default-features = false, features = ["scale-i
 scale-encode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"
+derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
 
 [dev-dependencies]
 bitvec = { version = "1.0.1", default-features = false }

--- a/scale-encode/src/error/mod.rs
+++ b/scale-encode/src/error/mod.rs
@@ -194,26 +194,13 @@ pub enum Kind {
 mod test {
     use super::*;
 
-    #[derive(Debug)]
+    #[derive(Debug, derive_more::Display)]
     enum MyError {
         Foo,
     }
 
-    impl Display for MyError {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            write!(f, "{self:?}")
-        }
-    }
-
     #[cfg(feature = "std")]
     impl std::error::Error for MyError {}
-
-    #[cfg(not(feature = "std"))]
-    impl Into<CustomError> for MyError {
-        fn into(self) -> CustomError {
-            Box::new(self)
-        }
-    }
 
     #[test]
     fn custom_error() {

--- a/scale-encode/src/error/mod.rs
+++ b/scale-encode/src/error/mod.rs
@@ -52,6 +52,15 @@ impl Error {
 
         Error::new(ErrorKind::Custom(Box::new(StrError(error))))
     }
+    /// Construct a custom error from an owned string.
+    pub fn custom_string(error: String) -> Error {
+        #[derive(derive_more::Display, Debug)]
+        pub struct StringError(String);
+        #[cfg(feature = "std")]
+        impl std::error::Error for StringError {}
+
+        Error::new(ErrorKind::Custom(Box::new(StringError(error))))
+    }
     /// Retrieve more information about what went wrong.
     pub fn kind(&self) -> &ErrorKind {
         &self.kind
@@ -117,7 +126,9 @@ pub enum ErrorKind {
         expected: u32,
     },
     /// The types line up, but the expected length of the target type is different from the length of the input value.
-    #[display(fmt = "Cannot encode to type; expected length {expected_len} but got length {actual_len}")]
+    #[display(
+        fmt = "Cannot encode to type; expected length {expected_len} but got length {actual_len}"
+    )]
     WrongLength {
         /// Length we have
         actual_len: usize,
@@ -156,13 +167,13 @@ pub enum ErrorKind {
 #[cfg(feature = "std")]
 pub trait CustomError: std::error::Error + Send + Sync + 'static {}
 #[cfg(feature = "std")]
-impl <T: std::error::Error + Send + Sync + 'static> CustomError for T {}
+impl<T: std::error::Error + Send + Sync + 'static> CustomError for T {}
 
 /// Anything implementing this trait can be used in [`ErrorKind::Custom`].
 #[cfg(not(feature = "std"))]
 pub trait CustomError: core::fmt::Debug + core::fmt::Display + Send + Sync + 'static {}
 #[cfg(not(feature = "std"))]
-impl <T: core::fmt::Debug + core::fmt::Display + Send + Sync + 'static> CustomError for T {}
+impl<T: core::fmt::Debug + core::fmt::Display + Send + Sync + 'static> CustomError for T {}
 
 /// The kind of type that we're trying to encode.
 #[allow(missing_docs)]


### PR DESCRIPTION
I standardised no_std errors to be `Display + Debug`, which is closer to the "real" `std::error::Error` trait (and is what `serde` does too for `no_std`), exposed a couple of helpers to make constructing them from strings simpler (`scale-value` and `subxt` use these) and made use of `derive_more` since it's used in `scale-value` anyway, and is rather helpful.

Also bumped the version ready for a new release once this merges.

Part of a series:

- https://github.com/paritytech/scale-decode/pull/31
- You are here: https://github.com/paritytech/scale-encode/pull/13
- https://github.com/paritytech/scale-value/pull/40

Changes tested against Subxt; I'll update that next.