### PR TITLE
Enable generic type encoding via `TypeResolver` and remove dependency on `scale-info`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,6 +71,16 @@ jobs:
           # we run tests using BitVec<u64,_> which doesn't.
           args: --all-features --target wasm32-unknown-unknown
 
+  diff-readme-files:
+    name: Check that READMEs are identical
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Diff READMEs
+        run: diff -q README.md scale-encode/README.md
+
   no_std:
     name: Check no_std build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,3 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [workspace.dependencies]
 scale-encode = { version = "0.5.0", path = "scale-encode" }
 scale-encode-derive = { version = "0.5.0", path = "scale-encode-derive" }
-
-[patch.crates-io]
-scale-type-resolver = { path = "../scale-type-resolver" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "scale-encode-derive",
     "testing/no_std",
 ]
+resolver = "2"
 
 [workspace.package]
 version = "0.5.0"
@@ -18,3 +19,6 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [workspace.dependencies]
 scale-encode = { version = "0.5.0", path = "scale-encode" }
 scale-encode-derive = { version = "0.5.0", path = "scale-encode-derive" }
+
+[patch.crates-io]
+scale-type-resolver = { path = "../scale-type-resolver" }

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # scale-encode
 
 `parity-scale-codec` provides an `Encode` trait which allows types to SCALE encode themselves based on their shape.
-This crate builds on this, and allows types to encode themselves based on `scale_info` type information. It
-exposes two traits:
+This crate builds on this, and allows types to encode themselves based on type information from a [`TypeResolver`]
+implementation (one such implementation being a `scale_info::PortableRegistry`). It exposes two traits:
 
-- An `EncodeAsType` trait which when implemented on some type, describes how it can be SCALE encoded
+- An [`EncodeAsType`] trait which when implemented on some type, describes how it can be SCALE encoded
   with the help of a type ID and type registry describing the expected shape of the encoded bytes.
-- An `EncodeAsFields` trait which when implemented on some type, describes how it can be SCALE encoded
-  with the help of a slice of `PortableField`'s or `PortableFieldId`'s and type registry describing the
-  expected shape of the encoded bytes. This is generally only implemented for tuples and structs, since we
-  need a set of fields to map to the provided slices.
+- An [`EncodeAsFields`] trait which when implemented on some type, describes how it can be SCALE encoded
+  with the help of an iterator over [`Field`]s and a type registry describing the expected shape of the
+  encoded bytes. This is generally only implemented for tuples and structs, since we need a set of fields
+  to map to the provided iterator.
 
-Implementations for many built-in types are also provided for each trait, and the `macro@EncodeAsType`
+Implementations for many built-in types are also provided for each trait, and the [`macro@EncodeAsType`]
 macro makes it easy to generate implementations for new structs and enums.
 
 # Motivation
@@ -24,14 +24,14 @@ use codec::Encode;
 use scale_encode::EncodeAsType;
 use scale_info::{PortableRegistry, TypeInfo};
 
-// We are comonly provided type information, but for our examples we construct type info from
+// We are commonly provided type information, but for our examples we construct type info from
 // any type that implements `TypeInfo`.
 fn get_type_info<T: TypeInfo + 'static>() -> (u32, PortableRegistry) {
     let m = scale_info::MetaType::new::<T>();
     let mut types = scale_info::Registry::new();
     let ty = types.register_type(&m);
     let portable_registry: PortableRegistry = types.into();
-    (ty.id(), portable_registry)
+    (ty.id, portable_registry)
 }
 
 // Encode the left value via EncodeAsType into the shape of the right value.
@@ -43,7 +43,7 @@ where
     B: TypeInfo + Encode + 'static,
 {
     let (type_id, types) = get_type_info::<B>();
-    let a_bytes = a.encode_as_type(type_id, &types).unwrap();
+    let a_bytes = a.encode_as_type(&type_id, &types).unwrap();
     let b_bytes = b.encode();
     assert_eq!(a_bytes, b_bytes);
 }

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # scale-encode
 
 `parity-scale-codec` provides an `Encode` trait which allows types to SCALE encode themselves based on their shape.
-This crate builds on this, and allows types to encode themselves based on type information from a [`TypeResolver`]
+This crate builds on this, and allows types to encode themselves based on type information from a `TypeResolver`
 implementation (one such implementation being a `scale_info::PortableRegistry`). It exposes two traits:
 
-- An [`EncodeAsType`] trait which when implemented on some type, describes how it can be SCALE encoded
+- An `EncodeAsType` trait which when implemented on some type, describes how it can be SCALE encoded
   with the help of a type ID and type registry describing the expected shape of the encoded bytes.
-- An [`EncodeAsFields`] trait which when implemented on some type, describes how it can be SCALE encoded
-  with the help of an iterator over [`Field`]s and a type registry describing the expected shape of the
+- An `EncodeAsFields` trait which when implemented on some type, describes how it can be SCALE encoded
+  with the help of an iterator over `Field`s and a type registry describing the expected shape of the
   encoded bytes. This is generally only implemented for tuples and structs, since we need a set of fields
   to map to the provided iterator.
 
-Implementations for many built-in types are also provided for each trait, and the [`macro@EncodeAsType`]
+Implementations for many built-in types are also provided for each trait, and the `EncodeAsType`
 macro makes it easy to generate implementations for new structs and enums.
 
 # Motivation

--- a/scale-encode-derive/src/lib.rs
+++ b/scale-encode-derive/src/lib.rs
@@ -137,7 +137,7 @@ fn generate_struct_impl(
                 __encode_as_type_out: &mut #path_to_scale_encode::Vec<u8>
             ) -> Result<(), #path_to_scale_encode::Error> {
                 let #path_to_type #matcher = self;
-                #composite.encode_composite_as_fields_to(
+                #composite.encode_composite_fields_to(
                     __encode_as_type_fields,
                     __encode_as_type_types,
                     __encode_as_type_out

--- a/scale-encode-derive/src/lib.rs
+++ b/scale-encode-derive/src/lib.rs
@@ -67,7 +67,7 @@ fn generate_enum_impl(
         quote!(
             Self::#variant_name #matcher => {
                 #path_to_scale_encode::Variant { name: #variant_name_str, fields: #composite }
-                    .encode_as_type_to(
+                    .encode_variant_as_type_to(
                         __encode_as_type_type_id,
                         __encode_as_type_types,
                         __encode_as_type_out
@@ -79,11 +79,11 @@ fn generate_enum_impl(
     quote!(
         impl #impl_generics #path_to_scale_encode::EncodeAsType for #path_to_type #ty_generics #where_clause {
             #[allow(unused_variables)]
-            fn encode_as_type_to(
+            fn encode_as_type_to<ScaleEncodeResolver: #path_to_scale_encode::TypeResolver>(
                 &self,
                 // long variable names to prevent conflict with struct field names:
-                __encode_as_type_type_id: u32,
-                __encode_as_type_types: &#path_to_scale_encode::PortableRegistry,
+                __encode_as_type_type_id: &ScaleEncodeResolver::TypeId,
+                __encode_as_type_types: &ScaleEncodeResolver,
                 __encode_as_type_out: &mut #path_to_scale_encode::Vec<u8>
             ) -> Result<(), #path_to_scale_encode::Error> {
                 match self {
@@ -112,15 +112,15 @@ fn generate_struct_impl(
     quote!(
         impl #impl_generics #path_to_scale_encode::EncodeAsType for #path_to_type #ty_generics #where_clause {
             #[allow(unused_variables)]
-            fn encode_as_type_to(
+            fn encode_as_type_to<ScaleEncodeResolver: #path_to_scale_encode::TypeResolver>(
                 &self,
                 // long variable names to prevent conflict with struct field names:
-                __encode_as_type_type_id: u32,
-                __encode_as_type_types: &#path_to_scale_encode::PortableRegistry,
+                __encode_as_type_type_id: &ScaleEncodeResolver::TypeId,
+                __encode_as_type_types: &ScaleEncodeResolver,
                 __encode_as_type_out: &mut #path_to_scale_encode::Vec<u8>
             ) -> Result<(), #path_to_scale_encode::Error> {
                 let #path_to_type #matcher = self;
-                #composite.encode_as_type_to(
+                #composite.encode_composite_as_type_to(
                     __encode_as_type_type_id,
                     __encode_as_type_types,
                     __encode_as_type_out
@@ -129,15 +129,15 @@ fn generate_struct_impl(
         }
         impl #impl_generics #path_to_scale_encode::EncodeAsFields for #path_to_type #ty_generics #where_clause {
             #[allow(unused_variables)]
-            fn encode_as_fields_to(
+            fn encode_as_fields_to<ScaleEncodeResolver: #path_to_scale_encode::TypeResolver>(
                 &self,
                 // long variable names to prevent conflict with struct field names:
-                __encode_as_type_fields: &mut dyn #path_to_scale_encode::FieldIter<'_>,
-                __encode_as_type_types: &#path_to_scale_encode::PortableRegistry,
+                __encode_as_type_fields: &mut dyn #path_to_scale_encode::FieldIter<'_, ScaleEncodeResolver::TypeId>,
+                __encode_as_type_types: &ScaleEncodeResolver,
                 __encode_as_type_out: &mut #path_to_scale_encode::Vec<u8>
             ) -> Result<(), #path_to_scale_encode::Error> {
                 let #path_to_type #matcher = self;
-                #composite.encode_as_fields_to(
+                #composite.encode_composite_as_fields_to(
                     __encode_as_type_fields,
                     __encode_as_type_types,
                     __encode_as_type_out
@@ -192,12 +192,12 @@ fn fields_to_matcher_and_composite(
                 .map(|f| {
                     let field_name_str = f.ident.as_ref().unwrap().to_string();
                     let field_name = &f.ident;
-                    quote!((Some(#field_name_str), #field_name as &dyn #path_to_scale_encode::EncodeAsType))
+                    quote!((Some(#field_name_str), #path_to_scale_encode::CompositeField::new(#field_name)))
                 });
 
             (
                 quote!({#( #match_body ),*}),
-                quote!(#path_to_scale_encode::Composite([#( #tuple_body ),*].into_iter())),
+                quote!(#path_to_scale_encode::Composite::new([#( #tuple_body ),*].into_iter())),
             )
         }
         syn::Fields::Unnamed(fields) => {
@@ -210,16 +210,16 @@ fn fields_to_matcher_and_composite(
             let match_body = field_idents.clone().map(|(i, _)| quote!(#i));
             let tuple_body = field_idents
                 .filter(|(_, f)| !should_skip(&f.attrs))
-                .map(|(i, _)| quote!((None as Option<&'static str>, #i as &dyn #path_to_scale_encode::EncodeAsType)));
+                .map(|(i, _)| quote!((None as Option<&'static str>, #path_to_scale_encode::CompositeField::new(#i))));
 
             (
                 quote!((#( #match_body ),*)),
-                quote!(#path_to_scale_encode::Composite([#( #tuple_body ),*].into_iter())),
+                quote!(#path_to_scale_encode::Composite::new([#( #tuple_body ),*].into_iter())),
             )
         }
         syn::Fields::Unit => (
             quote!(),
-            quote!(#path_to_scale_encode::Composite(([] as [(Option<&'static str>, &dyn #path_to_scale_encode::EncodeAsType);0]).into_iter())),
+            quote!(#path_to_scale_encode::Composite::new(([] as [(Option<&'static str>, #path_to_scale_encode::CompositeField<_>);0]).into_iter())),
         ),
     }
 }

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -30,8 +30,8 @@ bits = ["dep:scale-bits"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-type-resolver = "0.1.1"
-scale-bits = { version = "0.5.0", default-features = false, features = ["scale-info"], optional = true }
+scale-type-resolver = { version = "0.1.1", default-features = false, features = ["visitor"] }
+scale-bits = { version = "0.5.0", default-features = false, optional = true }
 scale-encode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"
@@ -45,3 +45,4 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 trybuild = "1.0.72"
 # enable scale-info feature for testing:
 primitive-types = { version = "0.12.0", default-features = false, features = ["scale-info"] }
+scale-type-resolver = { version = "0.1.1", default-features = false, features = ["scale-info"] }

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -17,7 +17,7 @@ include.workspace = true
 default = ["std", "derive", "primitive-types", "bits"]
 
 # Activates std feature.
-std = ["scale-info/std"]
+std = []
 
 # Include the derive proc macro.
 derive = ["dep:scale-encode-derive"]
@@ -39,7 +39,7 @@ derive_more = { version = "0.99.17", default-features = false, features = ["from
 
 [dev-dependencies]
 bitvec = { version = "1.0.1", default-features = false }
-scale-info = { version = "2.3.0", features = ["bit-vec", "derive"], default-features = false }
+scale-info = { version = "2.3.0", features = ["bit-vec", "derive", "std"], default-features = false }
 scale-encode-derive = { workspace = true }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "bit-vec"] }
 trybuild = "1.0.72"

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -31,7 +31,8 @@ bits = ["dep:scale-bits"]
 [dependencies]
 scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-bits = { version = "0.4.0", default-features = false, features = ["scale-info"], optional = true }
+scale-type-resolver = "0.1.0"
+scale-bits = { version = "0.5.0", default-features = false, features = ["scale-info"], optional = true }
 scale-encode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -30,7 +30,7 @@ bits = ["dep:scale-bits"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-type-resolver = "0.1.0"
+scale-type-resolver = "0.1.1"
 scale-bits = { version = "0.5.0", default-features = false, features = ["scale-info"], optional = true }
 scale-encode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -29,7 +29,6 @@ primitive-types = ["dep:primitive-types"]
 bits = ["dep:scale-bits"]
 
 [dependencies]
-scale-info = { version = "2.7.0", default-features = false, features = ["bit-vec"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 scale-type-resolver = "0.1.0"
 scale-bits = { version = "0.5.0", default-features = false, features = ["scale-info"], optional = true }

--- a/scale-encode/README.md
+++ b/scale-encode/README.md
@@ -1,17 +1,17 @@
 # scale-encode
 
 `parity-scale-codec` provides an `Encode` trait which allows types to SCALE encode themselves based on their shape.
-This crate builds on this, and allows types to encode themselves based on `scale_info` type information. It
-exposes two traits:
+This crate builds on this, and allows types to encode themselves based on type information from a [`TypeResolver`]
+implementation (one such implementation being a `scale_info::PortableRegistry`). It exposes two traits:
 
-- An `EncodeAsType` trait which when implemented on some type, describes how it can be SCALE encoded
+- An [`EncodeAsType`] trait which when implemented on some type, describes how it can be SCALE encoded
   with the help of a type ID and type registry describing the expected shape of the encoded bytes.
-- An `EncodeAsFields` trait which when implemented on some type, describes how it can be SCALE encoded
-  with the help of a slice of `PortableField`'s or `PortableFieldId`'s and type registry describing the
-  expected shape of the encoded bytes. This is generally only implemented for tuples and structs, since we
-  need a set of fields to map to the provided slices.
+- An [`EncodeAsFields`] trait which when implemented on some type, describes how it can be SCALE encoded
+  with the help of an iterator over [`Field`]s and a type registry describing the expected shape of the
+  encoded bytes. This is generally only implemented for tuples and structs, since we need a set of fields
+  to map to the provided iterator.
 
-Implementations for many built-in types are also provided for each trait, and the `macro@EncodeAsType`
+Implementations for many built-in types are also provided for each trait, and the [`macro@EncodeAsType`]
 macro makes it easy to generate implementations for new structs and enums.
 
 # Motivation
@@ -24,14 +24,14 @@ use codec::Encode;
 use scale_encode::EncodeAsType;
 use scale_info::{PortableRegistry, TypeInfo};
 
-// We are comonly provided type information, but for our examples we construct type info from
+// We are commonly provided type information, but for our examples we construct type info from
 // any type that implements `TypeInfo`.
 fn get_type_info<T: TypeInfo + 'static>() -> (u32, PortableRegistry) {
     let m = scale_info::MetaType::new::<T>();
     let mut types = scale_info::Registry::new();
     let ty = types.register_type(&m);
     let portable_registry: PortableRegistry = types.into();
-    (ty.id(), portable_registry)
+    (ty.id, portable_registry)
 }
 
 // Encode the left value via EncodeAsType into the shape of the right value.
@@ -43,7 +43,7 @@ where
     B: TypeInfo + Encode + 'static,
 {
     let (type_id, types) = get_type_info::<B>();
-    let a_bytes = a.encode_as_type(type_id, &types).unwrap();
+    let a_bytes = a.encode_as_type(&type_id, &types).unwrap();
     let b_bytes = b.encode();
     assert_eq!(a_bytes, b_bytes);
 }

--- a/scale-encode/README.md
+++ b/scale-encode/README.md
@@ -1,17 +1,17 @@
 # scale-encode
 
 `parity-scale-codec` provides an `Encode` trait which allows types to SCALE encode themselves based on their shape.
-This crate builds on this, and allows types to encode themselves based on type information from a [`TypeResolver`]
+This crate builds on this, and allows types to encode themselves based on type information from a `TypeResolver`
 implementation (one such implementation being a `scale_info::PortableRegistry`). It exposes two traits:
 
-- An [`EncodeAsType`] trait which when implemented on some type, describes how it can be SCALE encoded
+- An `EncodeAsType` trait which when implemented on some type, describes how it can be SCALE encoded
   with the help of a type ID and type registry describing the expected shape of the encoded bytes.
-- An [`EncodeAsFields`] trait which when implemented on some type, describes how it can be SCALE encoded
-  with the help of an iterator over [`Field`]s and a type registry describing the expected shape of the
+- An `EncodeAsFields` trait which when implemented on some type, describes how it can be SCALE encoded
+  with the help of an iterator over `Field`s and a type registry describing the expected shape of the
   encoded bytes. This is generally only implemented for tuples and structs, since we need a set of fields
   to map to the provided iterator.
 
-Implementations for many built-in types are also provided for each trait, and the [`macro@EncodeAsType`]
+Implementations for many built-in types are also provided for each trait, and the `EncodeAsType`
 macro makes it easy to generate implementations for new structs and enums.
 
 # Motivation

--- a/scale-encode/src/error/mod.rs
+++ b/scale-encode/src/error/mod.rs
@@ -139,7 +139,9 @@ pub enum ErrorKind {
         expected_len: usize,
     },
     /// We cannot encode the number given into the target type; it's out of range.
-    #[display(fmt = "Number {value} is out of range for target type with identifier {expected_id}")]
+    #[display(
+        fmt = "Number {value} is out of range for target type with identifier {expected_id}"
+    )]
     NumberOutOfRange {
         /// A string represenatation of the numeric value that was out of range.
         value: String,

--- a/scale-encode/src/error/mod.rs
+++ b/scale-encode/src/error/mod.rs
@@ -114,16 +114,19 @@ impl Display for Error {
 /// The underlying nature of the error.
 #[derive(Debug, derive_more::From, derive_more::Display)]
 pub enum ErrorKind {
+    /// There was an error resolving the type via the given [`crate::TypeResolver`].
+    #[display(fmt = "Failed to resolve type: {_0}")]
+    TypeResolvingError(String),
     /// Cannot find a given type.
-    #[display(fmt = "Cannot find type with ID {_0}")]
-    TypeNotFound(u32),
+    #[display(fmt = "Cannot find type with identifier {_0}")]
+    TypeNotFound(String),
     /// Cannot encode the actual type given into the target type ID.
-    #[display(fmt = "Cannot encode {actual:?} into type with ID {expected}")]
+    #[display(fmt = "Cannot encode {actual:?} into type with ID {expected_id}")]
     WrongShape {
         /// The actual kind we have to encode
         actual: Kind,
-        /// ID of the expected type.
-        expected: u32,
+        /// Identifier for the expected type
+        expected_id: String,
     },
     /// The types line up, but the expected length of the target type is different from the length of the input value.
     #[display(
@@ -136,20 +139,20 @@ pub enum ErrorKind {
         expected_len: usize,
     },
     /// We cannot encode the number given into the target type; it's out of range.
-    #[display(fmt = "Number {value} is out of range for target type {expected}")]
+    #[display(fmt = "Number {value} is out of range for target type with identifier {expected_id}")]
     NumberOutOfRange {
         /// A string represenatation of the numeric value that was out of range.
         value: String,
-        /// Id of the expected numeric type that we tried to encode it to.
-        expected: u32,
+        /// Identifier for the expected numeric type that we tried to encode it to.
+        expected_id: String,
     },
     /// Cannot find a variant with a matching name on the target type.
-    #[display(fmt = "Variant {name} does not exist on type with ID {expected}")]
+    #[display(fmt = "Variant {name} does not exist on type with identifier {expected_id}")]
     CannotFindVariant {
         /// Variant name we can't find in the expected type.
         name: String,
-        /// ID of the expected type.
-        expected: u32,
+        /// Identifier for the expected type.
+        expected_id: String,
     },
     /// Cannot find a field on our source type that's needed for the target type.
     #[display(fmt = "Field {name} does not exist in our source struct")]

--- a/scale-encode/src/impls/bits.rs
+++ b/scale-encode/src/impls/bits.rs
@@ -17,8 +17,8 @@ use crate::{
     error::{Error, ErrorKind, Kind},
     EncodeAsType,
 };
-use scale_type_resolver::{TypeResolver, visitor};
 use alloc::vec::Vec;
+use scale_type_resolver::{visitor, TypeResolver};
 
 impl EncodeAsType for scale_bits::Bits {
     fn encode_as_type_to<R: TypeResolver>(
@@ -29,12 +29,13 @@ impl EncodeAsType for scale_bits::Bits {
     ) -> Result<(), crate::Error> {
         let type_id = super::find_single_entry_with_same_repr(type_id, types);
 
-        let v = visitor::new(out, |_,_| Err(wrong_shape(type_id)))
-            .visit_bit_sequence(|out, store, order| {
+        let v = visitor::new(out, |_, _| Err(wrong_shape(type_id))).visit_bit_sequence(
+            |out, store, order| {
                 let format = scale_bits::Format { store, order };
                 scale_bits::encode_using_format_to(self.iter(), format, out);
                 Ok(())
-            });
+            },
+        );
 
         super::resolve_type_and_encode(types, type_id, v)
     }

--- a/scale-encode/src/impls/bits.rs
+++ b/scale-encode/src/impls/bits.rs
@@ -17,7 +17,7 @@ use crate::{
     error::{Error, ErrorKind, Kind},
     EncodeAsType,
 };
-use alloc::vec::Vec;
+use alloc::{format, vec::Vec};
 use scale_type_resolver::{visitor, TypeResolver};
 
 impl EncodeAsType for scale_bits::Bits {

--- a/scale-encode/src/impls/composite.rs
+++ b/scale-encode/src/impls/composite.rs
@@ -146,8 +146,8 @@ where
         }
     }
 
-    /// A shortcut for [`Self::encode_composite_as_type_to()`] for when you just
-    /// want it to allocate and return the encoded bytes.
+    /// A shortcut for [`Self::encode_composite_as_type_to()`] which internally
+    /// allocates a [`Vec`] and returns it.
     pub fn encode_composite_as_type(
         &self,
         type_id: &R::TypeId,
@@ -178,7 +178,7 @@ where
             if vals_iter_len == 1 {
                 return vals_iter
                     .next()
-                    .unwrap()
+                    .expect("1 value expected")
                     .1
                     .encode_composite_field_to(type_id, types, out);
             }
@@ -202,7 +202,7 @@ where
             if !is_named_vals && vals_iter_len == 1 {
                 return vals_iter
                     .next()
-                    .unwrap()
+                    .expect("1 value expected")
                     .1
                     .encode_composite_field_to(type_id, types, out);
             }
@@ -231,8 +231,8 @@ where
         super::resolve_type_and_encode(types, type_id, v)
     }
 
-    /// A shortcut for [`Self::encode_composite_fields_to()`] for when you just
-    /// want it to allocate and return the encoded bytes.
+    /// A shortcut for [`Self::encode_composite_fields_to()`] which internally
+    /// allocates a [`Vec`] and returns it.
     pub fn encode_composite_fields(
         &self,
         fields: &mut dyn FieldIter<'_, R::TypeId>,

--- a/scale-encode/src/impls/composite.rs
+++ b/scale-encode/src/impls/composite.rs
@@ -15,11 +15,67 @@
 
 use crate::{
     error::{Error, ErrorKind, Kind, Location},
-    EncodeAsFields, EncodeAsType, Field, FieldIter,
+    EncodeAsType, Field, FieldIter,
+    TypeResolver
 };
 use alloc::collections::BTreeMap;
 use alloc::{string::ToString, vec::Vec};
-use scale_info::{PortableRegistry, TypeDef};
+use scale_type_resolver::visitor;
+
+/// This trait exists to get around object safety issues using [`EncodeAsType`].
+/// It's object safe and automatically implemented for any type which implements
+/// [`EncodeAsType`]. We need this to construct generic [`Composite`] types.
+trait EncodeAsTypeWithResolver<R: TypeResolver> {
+    fn encode_as_type_with_resolver_to(
+        &self,
+        type_id: &R::TypeId,
+        types: &R,
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error>;
+}
+impl <T: EncodeAsType, R: TypeResolver> EncodeAsTypeWithResolver<R> for T {
+    fn encode_as_type_with_resolver_to(
+        &self,
+        type_id: &R::TypeId,
+        types: &R,
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error> {
+        self.encode_as_type_to(type_id, types, out)
+    }
+}
+
+/// A struct representing a single composite field. To be used in conjunction
+/// with the [`Composite`] struct to construct generic composite shaped types.
+/// this basically takes a type which implements [`EncodeAsType`] and turns it
+/// into something object safe.
+pub struct CompositeField<'a, R> {
+    val: &'a dyn EncodeAsTypeWithResolver<R>
+}
+
+impl <'a, R> Copy for CompositeField<'a, R> {}
+impl <'a, R> Clone for CompositeField<'a, R> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl <'a, R: TypeResolver> CompositeField<'a, R> {
+    /// Construct a new composite field given some type which implements
+    /// [`EncodeAsType`].
+    pub fn new<T: EncodeAsType>(val: &'a T) -> Self {
+        CompositeField { val }
+    }
+
+    /// SCALE encode this composite field to bytes based on the underlying type.
+    pub fn encode_composite_field_to(
+        &self,
+        type_id: &R::TypeId,
+        types: &R,
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error> {
+        self.val.encode_as_type_with_resolver_to(type_id, types, out)
+    }
+}
 
 /// This type represents named or unnamed composite values, and can be used
 /// to help generate `EncodeAsType` impls. It's primarily used by the exported
@@ -44,47 +100,69 @@ use scale_info::{PortableRegistry, TypeDef};
 ///     }
 /// }
 /// ```
-pub struct Composite<Vals>(pub Vals);
+pub struct Composite<R, Vals> {
+    vals: Vals,
+    marker: core::marker::PhantomData<R>
+}
 
-impl<'a, Vals> EncodeAsType for Composite<Vals>
+impl<'a, R, Vals> Composite<R, Vals>
 where
-    Vals: ExactSizeIterator<Item = (Option<&'a str>, &'a dyn EncodeAsType)> + Clone,
+    R: TypeResolver + 'a,
+    Vals: ExactSizeIterator<Item = (Option<&'a str>, CompositeField<'a, R>)> + Clone,
 {
-    fn encode_as_type_to(
+    /// Construct a new [`Composite`] type by providing an iterator over
+    /// the fields that it contains.
+    ///
+    /// ```rust
+    /// use scale_encode::{ Composite, CompositeField };
+    ///
+    /// Composite::new([
+    ///     (Some("foo"), CompositeField::new(&123)),
+    ///     (Some("bar"), CompositeField::new(&"hello"))
+    /// ].into_iter());
+    /// ```
+    pub fn new(vals: Vals) -> Self {
+        Composite { vals, marker: core::marker::PhantomData }
+    }
+
+    /// Encode this composite value as the provided type to the output bytes.
+    pub fn encode_composite_as_type_to(
         &self,
-        type_id: u32,
-        types: &PortableRegistry,
+        type_id: &R::TypeId,
+        types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
-        let mut vals_iter = self.0.clone();
+        let vals_iter = self.vals.clone();
         let vals_iter_len = vals_iter.len();
 
         // Skip through any single field composites/tuples without names. If there
         // are names, we may want to line up input field(s) on them.
         let type_id = skip_through_single_unnamed_fields(type_id, types);
 
-        let ty = types
-            .resolve(type_id)
-            .ok_or_else(|| Error::new(ErrorKind::TypeNotFound(type_id)))?;
-
-        match &ty.type_def {
-            // If we see a tuple type, it'll have more than one field else it'd have been skipped above.
-            TypeDef::Tuple(tuple) => {
-                // If there is exactly one val, it won't line up with the tuple then, so
-                // try encoding one level in instead.
+        let v = visitor
+            ::new((out, vals_iter), |(out, mut vals_iter), _| {
+                // Rather than immediately giving up, we should at least see whether
+                // we can skip one level in to our value and encode that.
                 if vals_iter_len == 1 {
                     return vals_iter
                         .next()
                         .unwrap()
                         .1
-                        .encode_as_type_to(type_id, types, out);
+                        .encode_composite_field_to(type_id, types, out);
                 }
 
-                let mut fields = tuple.fields.iter().map(|f| Field::unnamed(f.id));
-                self.encode_as_fields_to(&mut fields, types, out)
-            }
-            // If we see a composite type, it has either named fields or !=1 unnamed fields.
-            TypeDef::Composite(composite) => {
+                // If we get here, then it means the value we were given had more than
+                // one field, and the type we were given was ultimately some one-field thing
+                // that contained a non composite/tuple type, so it would never work out.
+                Err(Error::new(ErrorKind::WrongShape {
+                    actual: Kind::Tuple,
+                    expected_id: format!("{type_id:?}"),
+                }))
+            })
+            .visit_not_found(|_| {
+                Err(Error::new(ErrorKind::TypeNotFound(format!("{type_id:?}"))))
+            })
+            .visit_composite(|(out,mut vals_iter), mut fields| {
                 // If vals are named, we may need to line them up with some named composite.
                 // If they aren't named, we only care about lining up based on matching lengths.
                 let is_named_vals = vals_iter.clone().any(|(name, _)| name.is_some());
@@ -96,50 +174,37 @@ where
                         .next()
                         .unwrap()
                         .1
-                        .encode_as_type_to(type_id, types, out);
+                        .encode_composite_field_to(type_id, types, out);
                 }
 
-                let mut fields = composite
-                    .fields
-                    .iter()
-                    .map(|f| Field::new(f.ty.id, f.name.as_deref()));
-                self.encode_as_fields_to(&mut fields, types, out)
-            }
-            // We may have skipped through to some primitive or other type.
-            _ => {
-                // Rather than immediately giving up, we should at least see whether
-                // we can skip one level in to our value and encode that.
+                self.encode_composite_fields_to(&mut fields, types, out)
+            })
+            .visit_tuple(|(out,mut vals_iter), type_ids| {
+                // If there is exactly one val, it won't line up with the tuple then, so
+                // try encoding one level in instead.
                 if vals_iter_len == 1 {
                     return vals_iter
                         .next()
                         .unwrap()
                         .1
-                        .encode_as_type_to(type_id, types, out);
+                        .encode_composite_field_to(type_id, types, out);
                 }
 
-                // If we get here, then it means the value we were given had more than
-                // one field, and the type we were given was ultimately some one-field thing
-                // that contained a non composite/tuple type, so it would never work out.
-                Err(Error::new(ErrorKind::WrongShape {
-                    actual: Kind::Tuple,
-                    expected: type_id,
-                }))
-            }
-        }
-    }
-}
+                let mut fields = type_ids.map(|id| Field::unnamed(id));
+                self.encode_composite_fields_to(&mut fields as &mut dyn FieldIter<'_, R::TypeId>, types, out)
+            });
 
-impl<'a, Vals> EncodeAsFields for Composite<Vals>
-where
-    Vals: ExactSizeIterator<Item = (Option<&'a str>, &'a dyn EncodeAsType)> + Clone,
-{
-    fn encode_as_fields_to(
+        super::resolve_type_and_encode(types, type_id, v)
+    }
+
+    /// Encode the composite fields as the provided field description to the output bytes
+    pub fn encode_composite_fields_to(
         &self,
-        fields: &mut dyn FieldIter<'_>,
-        types: &PortableRegistry,
+        fields: &mut dyn FieldIter<'_, R::TypeId>,
+        types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
-        let vals_iter = self.0.clone();
+        let vals_iter = self.vals.clone();
 
         // Most of the time there aren't too many fields, so avoid allocation in most cases:
         let fields = smallvec::SmallVec::<[_; 16]>::from_iter(fields);
@@ -147,7 +212,7 @@ where
         // Both the target and source type have to have named fields for us to use
         // names to line them up.
         let is_named = {
-            let is_target_named = fields.iter().any(|f| f.name().is_some());
+            let is_target_named = fields.iter().any(|f| f.name.is_some());
             let is_source_named = vals_iter.clone().any(|(name, _)| name.is_some());
             is_target_named && is_source_named
         };
@@ -157,20 +222,20 @@ where
             // then encode to the target type by matching the names. If fields are
             // named, we don't even mind if the number of fields doesn't line up;
             // we just ignore any fields we provided that aren't needed.
-            let source_fields_by_name: BTreeMap<&str, &dyn EncodeAsType> = vals_iter
+            let source_fields_by_name: BTreeMap<&str, CompositeField<'a, R>> = vals_iter
                 .map(|(name, val)| (name.unwrap_or(""), val))
                 .collect();
 
             for field in fields {
                 // Find the field in our source type:
-                let name = field.name().unwrap_or("");
+                let name = field.name.unwrap_or("");
                 let Some(value) = source_fields_by_name.get(name) else {
                     return Err(Error::new(ErrorKind::CannotFindField { name: name.to_string() }))
                 };
 
                 // Encode the value to the output:
                 value
-                    .encode_as_type_to(field.id(), types, out)
+                    .encode_composite_field_to(field.id, types, out)
                     .map_err(|e| e.at_field(name.to_string()))?;
             }
 
@@ -188,7 +253,7 @@ where
             }
 
             for (idx, (field, (name, val))) in fields.iter().zip(vals_iter).enumerate() {
-                val.encode_as_type_to(field.id(), types, out).map_err(|e| {
+                val.encode_composite_field_to(field.id, types, out).map_err(|e| {
                     let loc = if let Some(name) = name {
                         Location::field(name.to_string())
                     } else {
@@ -204,19 +269,31 @@ where
 
 // Single unnamed fields carry no useful information and can be skipped through.
 // Single named fields may still be useful to line up with named composites.
-fn skip_through_single_unnamed_fields(type_id: u32, types: &PortableRegistry) -> u32 {
-    let Some(ty) = types.resolve(type_id) else {
-        return type_id
-    };
-    match &ty.type_def {
-        TypeDef::Tuple(tuple) if tuple.fields.len() == 1 => {
-            skip_through_single_unnamed_fields(tuple.fields[0].id, types)
-        }
-        TypeDef::Composite(composite)
-            if composite.fields.len() == 1 && composite.fields[0].name.is_none() =>
-        {
-            skip_through_single_unnamed_fields(composite.fields[0].ty.id, types)
-        }
-        _ => type_id,
-    }
+fn skip_through_single_unnamed_fields<'a, R: TypeResolver>(type_id: &'a R::TypeId, types: &'a R) -> &'a R::TypeId {
+    let v = visitor::new((), |_,_| type_id)
+        .visit_composite(|_,fields| {
+            // If exactly 1 unnamed field, recurse into it, else return current type ID.
+            let Some(f) = fields.next() else {
+                return type_id
+            };
+            let None = fields.next() else {
+                return type_id
+            };
+            if f.name.is_some() {
+                return type_id
+            }
+            skip_through_single_unnamed_fields(f.id, types)
+        })
+        .visit_tuple(|_,type_ids| {
+            // Else if exactly 1 tuple entry, recurse into it, else return current type ID.
+            let Some(type_id) = type_ids.next() else {
+                return type_id
+            };
+            let None = type_ids.next() else {
+                return type_id
+            };
+            skip_through_single_unnamed_fields(type_id, types)
+        });
+
+    types.resolve_type(type_id, v).unwrap_or(type_id)
 }

--- a/scale-encode/src/impls/composite.rs
+++ b/scale-encode/src/impls/composite.rs
@@ -18,7 +18,7 @@ use crate::{
     EncodeAsType, Field, FieldIter, TypeResolver,
 };
 use alloc::collections::BTreeMap;
-use alloc::{string::ToString, vec::Vec};
+use alloc::{format, string::ToString, vec::Vec};
 use scale_type_resolver::visitor;
 
 /// This trait exists to get around object safety issues using [`EncodeAsType`].
@@ -220,7 +220,7 @@ where
                     .encode_composite_field_to(type_id, types, out);
             }
 
-            let mut fields = type_ids.map(|id| Field::unnamed(id));
+            let mut fields = type_ids.map(Field::unnamed);
             self.encode_composite_fields_to(
                 &mut fields as &mut dyn FieldIter<'_, R::TypeId>,
                 types,

--- a/scale-encode/src/impls/mod.rs
+++ b/scale-encode/src/impls/mod.rs
@@ -805,16 +805,16 @@ mod test {
         assert_encodes_like_codec(());
         assert_encodes_like_codec((12345,));
         assert_encodes_like_codec((123u8, true));
-        // assert_encodes_like_codec((123u8, true, "hello"));
-        // // Encode isn't implemented for `char` (but we treat it as a u32):
-        // assert_encodes_like_codec((123u8, true, "hello".to_string(), 'a' as u32));
-        // assert_encodes_like_codec((
-        //     123u8,
-        //     true,
-        //     "hello".to_string(),
-        //     'a' as u32,
-        //     123_000_000_000u128,
-        // ));
+        assert_encodes_like_codec((123u8, true, "hello"));
+        // Encode isn't implemented for `char` (but we treat it as a u32):
+        assert_encodes_like_codec((123u8, true, "hello".to_string(), 'a' as u32));
+        assert_encodes_like_codec((
+            123u8,
+            true,
+            "hello".to_string(),
+            'a' as u32,
+            123_000_000_000u128,
+        ));
     }
 
     #[test]

--- a/scale-encode/src/impls/mod.rs
+++ b/scale-encode/src/impls/mod.rs
@@ -20,11 +20,6 @@ mod composite;
 mod primitive_types;
 mod variant;
 
-// Useful to help encode key-value types or custom variant types manually.
-// Primarily used in the derive macro.
-pub use composite::{Composite, CompositeField};
-pub use variant::Variant;
-
 use crate::{
     error::{Error, ErrorKind, Kind},
     EncodeAsFields, EncodeAsType,
@@ -33,6 +28,7 @@ use alloc::{
     borrow::ToOwned,
     boxed::Box,
     collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque},
+    format,
     rc::Rc,
     string::{String, ToString},
     sync::Arc,
@@ -49,6 +45,11 @@ use core::{
     time::Duration,
 };
 use scale_type_resolver::{visitor, FieldIter, Primitive, ResolvedTypeVisitor, TypeResolver};
+
+// Useful to help encode key-value types or custom variant types manually.
+// Primarily used in the derive macro.
+pub use composite::{Composite, CompositeField};
+pub use variant::Variant;
 
 fn resolve_type_and_encode<
     'resolver,

--- a/scale-encode/src/impls/mod.rs
+++ b/scale-encode/src/impls/mod.rs
@@ -22,13 +22,14 @@ mod variant;
 
 // Useful to help encode key-value types or custom variant types manually.
 // Primarily used in the derive macro.
-pub use composite::Composite;
+pub use composite::{ Composite, CompositeField };
 pub use variant::Variant;
 
 use crate::{
     error::{Error, ErrorKind, Kind},
-    EncodeAsFields, EncodeAsType, FieldIter,
+    EncodeAsFields, EncodeAsType,
 };
+use scale_type_resolver::{ visitor, FieldIter, Primitive, ResolvedTypeVisitor, TypeResolver };
 use alloc::{
     borrow::ToOwned,
     boxed::Box,
@@ -48,53 +49,77 @@ use core::{
     ops::{Range, RangeInclusive},
     time::Duration,
 };
-use scale_info::{PortableRegistry, TypeDef, TypeDefPrimitive};
+
+fn resolve_type_and_encode<'resolver, R: TypeResolver, V: ResolvedTypeVisitor<'resolver, TypeId=R::TypeId, Value=Result<(), Error>>>(types: &'resolver R, type_id: &R::TypeId, visitor: V) -> Result<(), Error> {
+    match types.resolve_type(type_id, visitor) {
+        Ok(res) => res,
+        Err(e) => Err(Error::new(ErrorKind::TypeResolvingError(e.to_string())))
+    }
+}
 
 impl EncodeAsType for bool {
-    fn encode_as_type_to(
+    fn encode_as_type_to<R: TypeResolver>(
         &self,
-        type_id: u32,
-        types: &PortableRegistry,
+        type_id: &R::TypeId,
+        types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
         let type_id = find_single_entry_with_same_repr(type_id, types);
-        let ty = types
-            .resolve(type_id)
-            .ok_or_else(|| Error::new(ErrorKind::TypeNotFound(type_id)))?;
 
-        if let TypeDef::Primitive(TypeDefPrimitive::Bool) = &ty.type_def {
-            self.encode_to(out);
-            Ok(())
-        } else {
-            Err(Error::new(ErrorKind::WrongShape {
+        let wrong_shape_err = || {
+            Error::new(ErrorKind::WrongShape {
                 actual: Kind::Bool,
-                expected: type_id,
-            }))
-        }
+                expected_id: format!("{type_id:?}"),
+            })
+        };
+
+        let v = visitor::new((),|_,_| Err(wrong_shape_err()))
+            .visit_primitive(|_,primitive| {
+                if primitive == Primitive::Bool {
+                    self.encode_to(out);
+                    Ok(())
+                } else {
+                    Err(wrong_shape_err())
+                }
+            })
+            .visit_not_found(|_| {
+                Err(Error::new(ErrorKind::TypeNotFound(format!("{type_id:?}"))))
+            });
+
+        resolve_type_and_encode(types, type_id, v)
     }
 }
 
 impl EncodeAsType for str {
-    fn encode_as_type_to(
+    fn encode_as_type_to<R: TypeResolver>(
         &self,
-        type_id: u32,
-        types: &PortableRegistry,
+        type_id: &R::TypeId,
+        types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
         let type_id = find_single_entry_with_same_repr(type_id, types);
-        let ty = types
-            .resolve(type_id)
-            .ok_or_else(|| Error::new(ErrorKind::TypeNotFound(type_id)))?;
 
-        if let TypeDef::Primitive(TypeDefPrimitive::Str) = &ty.type_def {
-            self.encode_to(out);
-            Ok(())
-        } else {
-            Err(Error::new(ErrorKind::WrongShape {
+        let wrong_shape_err = || {
+            Error::new(ErrorKind::WrongShape {
                 actual: Kind::Str,
-                expected: type_id,
-            }))
-        }
+                expected_id: format!("{type_id:?}"),
+            })
+        };
+
+        let v = visitor::new((),|_,_| Err(wrong_shape_err()))
+            .visit_primitive(|_,primitive| {
+                if primitive == Primitive::Str {
+                    self.encode_to(out);
+                    Ok(())
+                } else {
+                    Err(wrong_shape_err())
+                }
+            })
+            .visit_not_found(|_| {
+                Err(Error::new(ErrorKind::TypeNotFound(format!("{type_id:?}"))))
+            });
+
+        resolve_type_and_encode(types, type_id, v)
     }
 }
 
@@ -102,10 +127,10 @@ impl<'a, T> EncodeAsType for &'a T
 where
     T: EncodeAsType + ?Sized,
 {
-    fn encode_as_type_to(
+    fn encode_as_type_to<R: TypeResolver>(
         &self,
-        type_id: u32,
-        types: &PortableRegistry,
+        type_id: &R::TypeId,
+        types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
         (*self).encode_as_type_to(type_id, types, out)
@@ -116,10 +141,10 @@ impl<'a, T> EncodeAsType for alloc::borrow::Cow<'a, T>
 where
     T: 'a + EncodeAsType + ToOwned + ?Sized,
 {
-    fn encode_as_type_to(
+    fn encode_as_type_to<R: TypeResolver>(
         &self,
-        type_id: u32,
-        types: &PortableRegistry,
+        type_id: &R::TypeId,
+        types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
         (**self).encode_as_type_to(type_id, types, out)
@@ -130,10 +155,10 @@ impl<T> EncodeAsType for [T]
 where
     T: EncodeAsType,
 {
-    fn encode_as_type_to(
+    fn encode_as_type_to<R: TypeResolver>(
         &self,
-        type_id: u32,
-        types: &PortableRegistry,
+        type_id: &R::TypeId,
+        types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
         encode_iterable_sequence_to(self.len(), self.iter(), type_id, types, out)
@@ -141,10 +166,10 @@ where
 }
 
 impl<const N: usize, T: EncodeAsType> EncodeAsType for [T; N] {
-    fn encode_as_type_to(
+    fn encode_as_type_to<R: TypeResolver>(
         &self,
-        type_id: u32,
-        types: &PortableRegistry,
+        type_id: &R::TypeId,
+        types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
         self[..].encode_as_type_to(type_id, types, out)
@@ -152,10 +177,10 @@ impl<const N: usize, T: EncodeAsType> EncodeAsType for [T; N] {
 }
 
 impl<T> EncodeAsType for PhantomData<T> {
-    fn encode_as_type_to(
+    fn encode_as_type_to<R: TypeResolver>(
         &self,
-        type_id: u32,
-        types: &PortableRegistry,
+        type_id: &R::TypeId,
+        types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
         ().encode_as_type_to(type_id, types, out)
@@ -163,45 +188,45 @@ impl<T> EncodeAsType for PhantomData<T> {
 }
 
 impl<T: EncodeAsType, E: EncodeAsType> EncodeAsType for Result<T, E> {
-    fn encode_as_type_to(
+    fn encode_as_type_to<R: TypeResolver>(
         &self,
-        type_id: u32,
-        types: &PortableRegistry,
+        type_id: &R::TypeId,
+        types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
         match self {
             Ok(v) => Variant {
                 name: "Ok",
-                fields: Composite([(None, v as &dyn EncodeAsType)].iter().copied()),
+                fields: Composite::new([(None, CompositeField::new(v))].iter().copied()),
             }
-            .encode_as_type_to(type_id, types, out),
+            .encode_variant_as_type_to(type_id, types, out),
             Err(e) => Variant {
                 name: "Err",
-                fields: Composite([(None, e as &dyn EncodeAsType)].iter().copied()),
+                fields: Composite::new([(None, CompositeField::new(e))].iter().copied()),
             }
-            .encode_as_type_to(type_id, types, out),
+            .encode_variant_as_type_to(type_id, types, out),
         }
     }
 }
 
 impl<T: EncodeAsType> EncodeAsType for Option<T> {
-    fn encode_as_type_to(
+    fn encode_as_type_to<R: TypeResolver>(
         &self,
-        type_id: u32,
-        types: &PortableRegistry,
+        type_id: &R::TypeId,
+        types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
         match self {
             Some(v) => Variant {
                 name: "Some",
-                fields: Composite([(None, v as &dyn EncodeAsType)].iter().copied()),
+                fields: Composite::new([(None, CompositeField::new(v))].iter().copied()),
             }
-            .encode_as_type_to(type_id, types, out),
+            .encode_variant_as_type_to(type_id, types, out),
             None => Variant {
                 name: "None",
-                fields: Composite([].iter().copied()),
+                fields: Composite::new([].iter().copied()),
             }
-            .encode_as_type_to(type_id, types, out),
+            .encode_variant_as_type_to(type_id, types, out),
         }
     }
 }
@@ -210,73 +235,77 @@ impl<T: EncodeAsType> EncodeAsType for Option<T> {
 macro_rules! impl_encode_number {
     ($ty:ty) => {
         impl EncodeAsType for $ty {
-            fn encode_as_type_to(
+            fn encode_as_type_to<R: TypeResolver>(
                 &self,
-                type_id: u32,
-                types: &PortableRegistry,
+                type_id: &R::TypeId,
+                types: &R,
                 out: &mut Vec<u8>,
             ) -> Result<(), Error> {
                 let type_id = find_single_entry_with_same_repr(type_id, types);
 
-                let ty = types
-                    .resolve(type_id)
-                    .ok_or_else(|| Error::new(ErrorKind::TypeNotFound(type_id)))?;
+                let wrong_shape_err = || {
+                    Error::new(ErrorKind::WrongShape {
+                        actual: Kind::Number,
+                        expected_id: format!("{type_id:?}"),
+                    })
+                };
 
-                fn try_num<T: TryFrom<$ty> + Encode>(
-                    num: $ty,
-                    target_id: u32,
-                    out: &mut Vec<u8>,
-                ) -> Result<(), Error> {
-                    let n: T = num.try_into().map_err(|_| {
-                        Error::new(ErrorKind::NumberOutOfRange {
-                            value: num.to_string(),
-                            expected: target_id,
-                        })
-                    })?;
-                    n.encode_to(out);
-                    Ok(())
-                }
+                let v = visitor::new(out, |_out,_kind| Err(wrong_shape_err()))
+                    .visit_primitive(|out,primitive| {
+                        fn try_num<T: TryFrom<$ty> + Encode>(
+                            num: $ty,
+                            target_id: impl core::fmt::Debug,
+                            out: &mut Vec<u8>,
+                        ) -> Result<(), Error> {
+                            let n: T = num.try_into().map_err(|_| {
+                                Error::new(ErrorKind::NumberOutOfRange {
+                                    value: num.to_string(),
+                                    expected_id: format!("{target_id:?}"),
+                                })
+                            })?;
+                            n.encode_to(out);
+                            Ok(())
+                        }
 
-                match &ty.type_def {
-                    TypeDef::Primitive(TypeDefPrimitive::U8) => try_num::<u8>(*self, type_id, out),
-                    TypeDef::Primitive(TypeDefPrimitive::U16) => {
-                        try_num::<u16>(*self, type_id, out)
-                    }
-                    TypeDef::Primitive(TypeDefPrimitive::U32) => {
-                        try_num::<u32>(*self, type_id, out)
-                    }
-                    TypeDef::Primitive(TypeDefPrimitive::U64) => {
-                        try_num::<u64>(*self, type_id, out)
-                    }
-                    TypeDef::Primitive(TypeDefPrimitive::U128) => {
-                        try_num::<u128>(*self, type_id, out)
-                    }
-                    TypeDef::Primitive(TypeDefPrimitive::I8) => try_num::<i8>(*self, type_id, out),
-                    TypeDef::Primitive(TypeDefPrimitive::I16) => {
-                        try_num::<i16>(*self, type_id, out)
-                    }
-                    TypeDef::Primitive(TypeDefPrimitive::I32) => {
-                        try_num::<i32>(*self, type_id, out)
-                    }
-                    TypeDef::Primitive(TypeDefPrimitive::I64) => {
-                        try_num::<i64>(*self, type_id, out)
-                    }
-                    TypeDef::Primitive(TypeDefPrimitive::I128) => {
-                        try_num::<i128>(*self, type_id, out)
-                    }
-                    TypeDef::Compact(c) => {
-                        let type_id = find_single_entry_with_same_repr(c.type_param.id, types);
-
-                        let ty = types
-                            .resolve(type_id)
-                            .ok_or_else(|| Error::new(ErrorKind::TypeNotFound(type_id)))?;
+                        match primitive {
+                            Primitive::U8 => try_num::<u8>(*self, type_id, out),
+                            Primitive::U16 => {
+                                try_num::<u16>(*self, type_id, out)
+                            }
+                            Primitive::U32 => {
+                                try_num::<u32>(*self, type_id, out)
+                            }
+                            Primitive::U64 => {
+                                try_num::<u64>(*self, type_id, out)
+                            }
+                            Primitive::U128 => {
+                                try_num::<u128>(*self, type_id, out)
+                            }
+                            Primitive::I8 => try_num::<i8>(*self, type_id, out),
+                            Primitive::I16 => {
+                                try_num::<i16>(*self, type_id, out)
+                            }
+                            Primitive::I32 => {
+                                try_num::<i32>(*self, type_id, out)
+                            }
+                            Primitive::I64 => {
+                                try_num::<i64>(*self, type_id, out)
+                            }
+                            Primitive::I128 => {
+                                try_num::<i128>(*self, type_id, out)
+                            },
+                            _ => Err(wrong_shape_err()),
+                        }
+                    })
+                    .visit_compact(|out,type_id| {
+                        let type_id = find_single_entry_with_same_repr(type_id, types);
 
                         macro_rules! try_compact_num {
                             ($num:expr, $target_kind:expr, $out:expr, $type:ty) => {{
                                 let n: $type = $num.try_into().map_err(|_| {
                                     Error::new(ErrorKind::NumberOutOfRange {
                                         value: $num.to_string(),
-                                        expected: type_id,
+                                        expected_id: format!("{type_id:?}"),
                                     })
                                 })?;
                                 Compact(n).encode_to($out);
@@ -284,33 +313,35 @@ macro_rules! impl_encode_number {
                             }};
                         }
 
-                        match ty.type_def {
-                            TypeDef::Primitive(TypeDefPrimitive::U8) => {
-                                try_compact_num!(*self, NumericKind::U8, out, u8)
-                            }
-                            TypeDef::Primitive(TypeDefPrimitive::U16) => {
-                                try_compact_num!(*self, NumericKind::U16, out, u16)
-                            }
-                            TypeDef::Primitive(TypeDefPrimitive::U32) => {
-                                try_compact_num!(*self, NumericKind::U32, out, u32)
-                            }
-                            TypeDef::Primitive(TypeDefPrimitive::U64) => {
-                                try_compact_num!(*self, NumericKind::U64, out, u64)
-                            }
-                            TypeDef::Primitive(TypeDefPrimitive::U128) => {
-                                try_compact_num!(*self, NumericKind::U128, out, u128)
-                            }
-                            _ => Err(Error::new(ErrorKind::WrongShape {
-                                actual: Kind::Number,
-                                expected: type_id,
-                            })),
-                        }
-                    }
-                    _ => Err(Error::new(ErrorKind::WrongShape {
-                        actual: Kind::Number,
-                        expected: type_id,
-                    })),
-                }
+                        let v = visitor::new(out,|_,_| Err(wrong_shape_err()))
+                            .visit_primitive(|out,primitive| {
+                                match primitive {
+                                    Primitive::U8 => {
+                                        try_compact_num!(*self, NumericKind::U8, out, u8)
+                                    }
+                                    Primitive::U16 => {
+                                        try_compact_num!(*self, NumericKind::U16, out, u16)
+                                    }
+                                    Primitive::U32 => {
+                                        try_compact_num!(*self, NumericKind::U32, out, u32)
+                                    }
+                                    Primitive::U64 => {
+                                        try_compact_num!(*self, NumericKind::U64, out, u64)
+                                    }
+                                    Primitive::U128 => {
+                                        try_compact_num!(*self, NumericKind::U128, out, u128)
+                                    }
+                                    _ => Err(wrong_shape_err()),
+                                }
+                            });
+
+                        resolve_type_and_encode(types, type_id, v)
+                    })
+                    .visit_not_found(|_out| {
+                        Err(Error::new(ErrorKind::TypeNotFound(format!("{type_id:?}"))))
+                    });
+
+                resolve_type_and_encode(types, type_id, v)
             }
         }
     };
@@ -332,13 +363,13 @@ impl_encode_number!(isize);
 macro_rules! impl_encode_tuple {
     ($($name:ident: $t:ident),*) => {
         impl < $($t),* > EncodeAsType for ($($t,)*) where $($t: EncodeAsType),* {
-            fn encode_as_type_to(&self, type_id: u32, types: &PortableRegistry, out: &mut Vec<u8>) -> Result<(), Error> {
+            fn encode_as_type_to<Resolver: TypeResolver>(&self, type_id: &Resolver::TypeId, types: &Resolver, out: &mut Vec<u8>) -> Result<(), Error> {
                 let ($($name,)*) = self;
-                Composite([
+                Composite::new([
                     $(
-                        (None as Option<&'static str>, $name as &dyn EncodeAsType)
+                        (None as Option<&'static str>, CompositeField::new($name))
                     ,)*
-                ].iter().copied()).encode_as_type_to(type_id, types, out)
+                ].iter().copied()).encode_composite_as_type_to(type_id, types, out)
             }
         }
     }
@@ -374,7 +405,12 @@ macro_rules! impl_encode_seq_via_iterator {
         impl $(< $($param),+ >)? EncodeAsType for $ty $(< $($param),+ >)?
         where $( $($param: EncodeAsType),+ )?
         {
-            fn encode_as_type_to(&self, type_id: u32, types: &PortableRegistry, out: &mut Vec<u8>) -> Result<(), Error> {
+            fn encode_as_type_to<R: TypeResolver>(
+                &self,
+                type_id: &R::TypeId,
+                types: &R,
+                out: &mut Vec<u8>,
+            ) -> Result<(), Error> {
                 encode_iterable_sequence_to(self.len(), self.iter(), type_id, types, out)
             }
         }
@@ -387,39 +423,42 @@ impl_encode_seq_via_iterator!(VecDeque[V]);
 impl_encode_seq_via_iterator!(Vec[V]);
 
 impl<K: AsRef<str>, V: EncodeAsType> EncodeAsType for BTreeMap<K, V> {
-    fn encode_as_type_to(
+    fn encode_as_type_to<R: TypeResolver>(
         &self,
-        type_id: u32,
-        types: &PortableRegistry,
+        type_id: &R::TypeId,
+        types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
-        let ty = types
-            .resolve(type_id)
-            .ok_or_else(|| Error::new(ErrorKind::TypeNotFound(type_id)))?;
+        let v = visitor
+            ::new(out,|out,_| {
+                Composite::new(
+                    self.iter()
+                        .map(|(k, v)| (Some(k.as_ref()), CompositeField::new(v))),
+                )
+                .encode_composite_as_type_to(type_id, types, out)
+            })
+            .visit_array(|out,_,_| {
+                encode_iterable_sequence_to(self.len(), self.values(), type_id, types, out)
+            })
+            .visit_sequence(|out,_| {
+                encode_iterable_sequence_to(self.len(), self.values(), type_id, types, out)
+            });
 
-        if matches!(ty.type_def, TypeDef::Array(_) | TypeDef::Sequence(_)) {
-            encode_iterable_sequence_to(self.len(), self.values(), type_id, types, out)
-        } else {
-            Composite(
-                self.iter()
-                    .map(|(k, v)| (Some(k.as_ref()), v as &dyn EncodeAsType)),
-            )
-            .encode_as_type_to(type_id, types, out)
-        }
+        resolve_type_and_encode(types, type_id, v)
     }
 }
 impl<K: AsRef<str>, V: EncodeAsType> EncodeAsFields for BTreeMap<K, V> {
-    fn encode_as_fields_to(
+    fn encode_as_fields_to<R: TypeResolver>(
         &self,
-        fields: &mut dyn FieldIter<'_>,
-        types: &PortableRegistry,
+        fields: &mut dyn FieldIter<'_, R::TypeId>,
+        types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
-        Composite(
+        Composite::new(
             self.iter()
-                .map(|(k, v)| (Some(k.as_ref()), v as &dyn EncodeAsType)),
+                .map(|(k, v)| (Some(k.as_ref()), CompositeField::new(v))),
         )
-        .encode_as_fields_to(fields, types, out)
+        .encode_composite_fields_to(fields, types, out)
     }
 }
 
@@ -428,7 +467,12 @@ impl<K: AsRef<str>, V: EncodeAsType> EncodeAsFields for BTreeMap<K, V> {
 macro_rules! impl_encode_like {
     ($ty:ident $(<$( $param:ident ),+>)? as $delegate_ty:ty where |$val:ident| $expr:expr) => {
         impl $(< $($param: EncodeAsType),+ >)? EncodeAsType for $ty $(<$( $param ),+>)? {
-            fn encode_as_type_to(&self, type_id: u32, types: &PortableRegistry, out: &mut Vec<u8>) -> Result<(), Error> {
+            fn encode_as_type_to<R: TypeResolver>(
+                &self,
+                type_id: &R::TypeId,
+                types: &R,
+                out: &mut Vec<u8>,
+            ) -> Result<(), Error> {
                 let delegate: $delegate_ty = {
                     let $val = self;
                     $expr
@@ -461,75 +505,90 @@ impl_encode_like!(Compact<T> as &T where |val| &val.0);
 // Attempt to recurse into some type, returning the innermost type found that has an identical
 // SCALE encoded representation to the given type. For instance, `(T,)` encodes identically to
 // `T`, as does `Mytype { inner: T }` or `[T; 1]`.
-fn find_single_entry_with_same_repr(type_id: u32, types: &PortableRegistry) -> u32 {
-    let Some(ty) = types.resolve(type_id) else {
-        return type_id
-    };
-    match &ty.type_def {
-        TypeDef::Tuple(tuple) if tuple.fields.len() == 1 => {
-            find_single_entry_with_same_repr(tuple.fields[0].id, types)
-        }
-        TypeDef::Composite(composite) if composite.fields.len() == 1 => {
-            find_single_entry_with_same_repr(composite.fields[0].ty.id, types)
-        }
-        _ => type_id,
-    }
+fn find_single_entry_with_same_repr<'resolver, R: TypeResolver>(type_id: &'resolver R::TypeId, types: &'resolver R) -> &'resolver R::TypeId {
+    let v = visitor::new((),|_,_| type_id)
+        .visit_tuple(|_,fields| {
+            let Some(field_ty_id) = fields.next() else {
+                return type_id
+            };
+            if fields.next().is_some() {
+                return type_id
+            }
+            field_ty_id
+        })
+        .visit_composite(|_,fields| {
+            let Some(field) = fields.next() else {
+                return type_id
+            };
+            if fields.next().is_some() {
+                return type_id
+            }
+            field.id
+        });
+
+    types.resolve_type(type_id, v).unwrap_or(type_id)
 }
 
 // Encode some iterator of items to the type provided.
-fn encode_iterable_sequence_to<I>(
+fn encode_iterable_sequence_to<I, R>(
     len: usize,
     it: I,
-    type_id: u32,
-    types: &PortableRegistry,
+    type_id: &R::TypeId,
+    types: &R,
     out: &mut Vec<u8>,
 ) -> Result<(), Error>
 where
     I: Iterator,
     I::Item: EncodeAsType,
+    R: TypeResolver
 {
-    let ty = types
-        .resolve(type_id)
-        .ok_or_else(|| Error::new(ErrorKind::TypeNotFound(type_id)))?;
+    let wrong_shape_err = || {
+        Error::new(ErrorKind::WrongShape {
+            actual: Kind::Array,
+            expected_id: format!("{type_id:?}"),
+        })
+    };
 
-    match &ty.type_def {
-        TypeDef::Array(arr) => {
-            if arr.len == len as u32 {
+    let v = visitor::new((it,out), |_,_| Err(wrong_shape_err()))
+        .visit_array(|(it,out), inner_ty_id, array_len| {
+            if array_len == len {
                 for (idx, item) in it.enumerate() {
-                    item.encode_as_type_to(arr.type_param.id, types, out)
+                    item.encode_as_type_to(inner_ty_id, types, out)
                         .map_err(|e| e.at_idx(idx))?;
                 }
                 Ok(())
             } else {
                 Err(Error::new(ErrorKind::WrongLength {
                     actual_len: len,
-                    expected_len: arr.len as usize,
+                    expected_len: array_len,
                 }))
             }
-        }
-        TypeDef::Sequence(seq) => {
+        })
+        .visit_sequence(|(it,out), inner_ty_id| {
             // Sequences are prefixed with their compact encoded length:
             Compact(len as u32).encode_to(out);
             for (idx, item) in it.enumerate() {
-                item.encode_as_type_to(seq.type_param.id, types, out)
+                item.encode_as_type_to(inner_ty_id, types, out)
                     .map_err(|e| e.at_idx(idx))?;
             }
             Ok(())
-        }
-        // if the target type is a basic newtype wrapper, then dig into that and try encoding to
-        // the thing inside it. This is fairly common, and allowing this means that users don't have
-        // to wrap things needlessly just to make types line up.
-        TypeDef::Tuple(tup) if tup.fields.len() == 1 => {
-            encode_iterable_sequence_to(len, it, tup.fields[0].id, types, out)
-        }
-        TypeDef::Composite(com) if com.fields.len() == 1 => {
-            encode_iterable_sequence_to(len, it, com.fields[0].ty.id, types, out)
-        }
-        _ => Err(Error::new(ErrorKind::WrongShape {
-            actual: Kind::Array,
-            expected: type_id,
-        })),
-    }
+        })
+        .visit_tuple(|(it,out), inner_type_ids| {
+            if inner_type_ids.len() == 1 {
+                encode_iterable_sequence_to(len, it, inner_type_ids.next().unwrap(), types, out)
+            } else {
+                Err(wrong_shape_err())
+            }
+        })
+        .visit_composite(|(it,out), fields| {
+            if fields.len() == 1 {
+                encode_iterable_sequence_to(len, it, fields.next().unwrap().id, types, out)
+            } else {
+                Err(wrong_shape_err())
+            }
+        });
+
+    resolve_type_and_encode(types, type_id, v)
 }
 
 #[cfg(all(feature = "derive", feature = "bits", feature = "primitive-types"))]
@@ -540,7 +599,7 @@ mod test {
     use alloc::vec;
     use codec::Decode;
     use core::fmt::Debug;
-    use scale_info::TypeInfo;
+    use scale_info::{ TypeInfo, PortableRegistry };
 
     /// Given a type definition, return type ID and registry representing it.
     fn make_type<T: TypeInfo + 'static>() -> (u32, PortableRegistry) {
@@ -554,7 +613,7 @@ mod test {
 
     fn encode_type<V: EncodeAsType, T: TypeInfo + 'static>(value: V) -> Result<Vec<u8>, Error> {
         let (type_id, types) = make_type::<T>();
-        let bytes = value.encode_as_type(type_id, &types)?;
+        let bytes = value.encode_as_type(&type_id, &types)?;
         Ok(bytes)
     }
 
@@ -603,11 +662,11 @@ mod test {
                 let mut fields = c
                     .fields
                     .iter()
-                    .map(|f| Field::new(f.ty.id, f.name.as_deref()));
+                    .map(|f| Field::new(&f.ty.id, f.name.as_deref()));
                 value.encode_as_fields(&mut fields, &types).unwrap()
             }
             scale_info::TypeDef::Tuple(t) => {
-                let mut fields = t.fields.iter().map(|f| Field::unnamed(f.id));
+                let mut fields = t.fields.iter().map(|f| Field::unnamed(&f.id));
                 value.encode_as_fields(&mut fields, &types).unwrap()
             }
             _ => {
@@ -682,7 +741,7 @@ mod test {
         let (type_id, types) = make_type::<Vec<u8>>();
         let e = vec![1u8, 2, 3].encode();
         let e2 = vec![1u8, 2, 3]
-            .encode_as_type(type_id, &types)
+            .encode_as_type(&type_id, &types)
             .expect("can encode 2");
         assert_eq!(e, e2);
     }
@@ -846,7 +905,7 @@ mod test {
             (Some("bar"), &12345u128 as &dyn EncodeAsType),
             (Some("wibble"), &true as &dyn EncodeAsType),
         ];
-        let source = Composite(vals.iter().copied());
+        let source = Composite::new(vals.iter().copied());
 
         let target = Foo {
             bar: 12345,
@@ -864,18 +923,18 @@ mod test {
 
         // note: unnamed target so fields need to be in order (can be named or not)
         let named_vals = [
-            (Some("bar"), &12345u128 as &dyn EncodeAsType),
-            (Some("wibble"), &true as &dyn EncodeAsType),
-            (Some("hello"), &"world".to_string() as &dyn EncodeAsType),
+            (Some("bar"), CompositeField::new(&12345u128)),
+            (Some("wibble"), CompositeField::new(&true)),
+            (Some("hello"), CompositeField::new(&"world".to_string())),
         ];
-        let source = Composite(named_vals.iter().copied());
+        let source = Composite::new(named_vals.iter().copied());
 
         let unnamed_vals = [
-            (None, &12345u128 as &dyn EncodeAsType),
-            (None, &true as &dyn EncodeAsType),
-            (None, &"world".to_string() as &dyn EncodeAsType),
+            (None, CompositeField::new(&12345u128)),
+            (None, CompositeField::new(&true)),
+            (None, CompositeField::new(&"world".to_string())),
         ];
-        let source2 = Composite(unnamed_vals.iter().copied());
+        let source2 = Composite::new(unnamed_vals.iter().copied());
 
         let target = Foo(12345, true, "world".to_string());
 
@@ -894,12 +953,12 @@ mod test {
 
         // note: fields do not need to be in order when named:
         let vals = [
-            (Some("hello"), &"world".to_string() as &dyn EncodeAsType),
-            (Some("bar"), &12345u128 as &dyn EncodeAsType),
+            (Some("hello"), CompositeField::new(&"world".to_string())),
+            (Some("bar"), CompositeField::new(&12345u128)),
             // wrong name:
-            (Some("wibbles"), &true as &dyn EncodeAsType),
+            (Some("wibbles"), CompositeField::new(&true)),
         ];
-        let source = Composite(vals.iter().copied());
+        let source = Composite::new(vals.iter().copied());
 
         encode_type::<_, Foo>(source).unwrap_err();
     }

--- a/scale-encode/src/impls/primitive_types.rs
+++ b/scale-encode/src/impls/primitive_types.rs
@@ -16,11 +16,17 @@
 use crate::{error::Error, EncodeAsType};
 use alloc::vec::Vec;
 use primitive_types::{H128, H160, H256, H384, H512, H768};
+use scale_type_resolver::TypeResolver;
 
 macro_rules! impl_encode {
     ($($ty:ty),*) => {$(
         impl EncodeAsType for $ty {
-            fn encode_as_type_to(&self, type_id: u32, types: &scale_info::PortableRegistry, out: &mut Vec<u8>) -> Result<(), Error> {
+            fn encode_as_type_to<R: TypeResolver>(
+                &self,
+                type_id: &R::TypeId,
+                types: &R,
+                out: &mut Vec<u8>,
+            ) -> Result<(), Error> {
                 let type_id = super::find_single_entry_with_same_repr(type_id, types);
                 self.0.encode_as_type_to(type_id, types, out)
             }

--- a/scale-encode/src/impls/variant.rs
+++ b/scale-encode/src/impls/variant.rs
@@ -15,7 +15,7 @@
 
 use super::composite::{Composite, CompositeField};
 use crate::error::{Error, ErrorKind, Kind};
-use alloc::{string::ToString, vec::Vec};
+use alloc::{format, string::ToString, vec::Vec};
 use codec::Encode;
 use scale_type_resolver::{visitor, TypeResolver};
 

--- a/scale-encode/src/impls/variant.rs
+++ b/scale-encode/src/impls/variant.rs
@@ -70,8 +70,8 @@ where
     R: TypeResolver + 'a,
     Vals: ExactSizeIterator<Item = (Option<&'a str>, CompositeField<'a, R>)> + Clone,
 {
-    /// A shortcut for [`Self::encode_variant_as_type_to()`] for when you just
-    /// want it to allocate and return the encoded bytes.
+    /// A shortcut for [`Self::encode_variant_as_type_to()`] which internally
+    /// allocates a [`Vec`] and returns it.
     pub fn encode_variant_as_type(&self, type_id: &R::TypeId, types: &R) -> Result<Vec<u8>, Error> {
         let mut out = Vec::new();
         self.encode_variant_as_type_to(type_id, types, &mut out)?;

--- a/scale-encode/src/lib.rs
+++ b/scale-encode/src/lib.rs
@@ -47,7 +47,7 @@ fn get_type_info<T: TypeInfo + 'static>() -> (u32, PortableRegistry) {
     let mut types = scale_info::Registry::new();
     let ty = types.register_type(&m);
     let portable_registry: PortableRegistry = types.into();
-    (ty.id(), portable_registry)
+    (ty.id, portable_registry)
 }
 
 // Encode the left value via EncodeAsType into the shape of the right value.
@@ -59,7 +59,7 @@ where
     B: TypeInfo + Encode + 'static,
 {
     let (type_id, types) = get_type_info::<B>();
-    let a_bytes = a.encode_as_type(type_id, &types).unwrap();
+    let a_bytes = a.encode_as_type(&type_id, &types).unwrap();
     let b_bytes = b.encode();
     assert_eq!(a_bytes, b_bytes);
 }
@@ -152,11 +152,10 @@ pub mod error;
 pub use alloc::vec::Vec;
 
 pub use error::Error;
-pub use scale_type_resolver::{ TypeResolver, FieldIter, Field };
 
 // Useful types to help implement EncodeAsType/Fields with:
 pub use crate::impls::{Composite, CompositeField, Variant};
-pub use scale_info::PortableRegistry;
+pub use scale_type_resolver::{Field, FieldIter, TypeResolver};
 
 /// Re-exports of external crates.
 pub mod ext {
@@ -181,7 +180,7 @@ pub trait EncodeAsType {
     fn encode_as_type<R: TypeResolver>(
         &self,
         type_id: &R::TypeId,
-        types: &R
+        types: &R,
     ) -> Result<Vec<u8>, Error> {
         let mut out = Vec::new();
         self.encode_as_type_to(type_id, types, &mut out)?;

--- a/scale-encode/src/lib.rs
+++ b/scale-encode/src/lib.rs
@@ -17,8 +17,8 @@
 
 /*!
 `parity-scale-codec` provides an `Encode` trait which allows types to SCALE encode themselves based on their shape.
-This crate builds on this, and allows types to encode themselves based on [`scale_info`] type information. It
-exposes two traits:
+This crate builds on this, and allows types to encode themselves based on type information from a [`TypeResolver`]
+implementation (one such implementation being a `scale_info::PortableRegistry`). It exposes two traits:
 
 - An [`EncodeAsType`] trait which when implemented on some type, describes how it can be SCALE encoded
   with the help of a type ID and type registry describing the expected shape of the encoded bytes.
@@ -164,7 +164,7 @@ pub mod ext {
 }
 
 /// This trait signals that some static type can possibly be SCALE encoded given some
-/// `type_id` and [`PortableRegistry`] which dictates the expected encoding.
+/// `type_id` and a corresponding [`TypeResolver`] which tells us about the expected encoding.
 pub trait EncodeAsType {
     /// Given some `type_id`, `types`, a `context` and some output target for the SCALE encoded bytes,
     /// attempt to SCALE encode the current value into the type given by `type_id`.


### PR DESCRIPTION
This replaces all uses of `scale-info` with `scale_type_resolver::TypeResolver` and `scale_type_resolver::visitor`'s to handle resolving types in the various impls.