### PR TITLE
Bump to scale-type-resolver 0.2 and prep for 0.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [v0.7.0] - 2024-04-29
+
+Update the `scale-type-resolver` dependency to 0.2.0 (and bump `scale-bits` for the same reason).
+
+The main change here is that type IDs are now passed by value, rather than reference.
+
 ## [v0.6.0] - 2024-02-16
 
 Up until now, `scale-info` has been the library that gives us the information needed to know how to SCALE encode values to the correct shape. In this release, we remove it from our dependency tree and replace it with `scale-type-resolver`, which provides a generic `TypeResolver` trait whose implementations are able to provide the information needed to encode/decode types. So now, rather than taking in a `scale_info::PortableRegistry`, the `EncodeAsType` and `EncodeAsFields` traits take a generic `R: scale_type_resolver::TypeResolver` value. `scale_info::PortableRegistry` implements `TypeResolver`, and so it can continue to be used similarly to before (though now, `type_id` is passed as a reference), but now we are generic over where the type information we need comes from.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -17,8 +17,5 @@ keywords = ["parity", "scale", "encoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [workspace.dependencies]
-scale-encode = { version = "0.6.0", path = "scale-encode" }
-scale-encode-derive = { version = "0.6.0", path = "scale-encode-derive" }
-
-[patch.crates-io]
-scale-type-resolver = { path = "../scale-type-resolver" }
+scale-encode = { version = "0.7.0", path = "scale-encode" }
+scale-encode-derive = { version = "0.7.0", path = "scale-encode-derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [workspace.dependencies]
 scale-encode = { version = "0.6.0", path = "scale-encode" }
 scale-encode-derive = { version = "0.6.0", path = "scale-encode-derive" }
+
+[patch.crates-io]
+scale-type-resolver = { path = "../scale-type-resolver" }

--- a/scale-encode-derive/src/lib.rs
+++ b/scale-encode-derive/src/lib.rs
@@ -82,7 +82,7 @@ fn generate_enum_impl(
             fn encode_as_type_to<ScaleEncodeResolver: #path_to_scale_encode::TypeResolver>(
                 &self,
                 // long variable names to prevent conflict with struct field names:
-                __encode_as_type_type_id: &ScaleEncodeResolver::TypeId,
+                __encode_as_type_type_id: ScaleEncodeResolver::TypeId,
                 __encode_as_type_types: &ScaleEncodeResolver,
                 __encode_as_type_out: &mut #path_to_scale_encode::Vec<u8>
             ) -> Result<(), #path_to_scale_encode::Error> {
@@ -115,7 +115,7 @@ fn generate_struct_impl(
             fn encode_as_type_to<ScaleEncodeResolver: #path_to_scale_encode::TypeResolver>(
                 &self,
                 // long variable names to prevent conflict with struct field names:
-                __encode_as_type_type_id: &ScaleEncodeResolver::TypeId,
+                __encode_as_type_type_id: ScaleEncodeResolver::TypeId,
                 __encode_as_type_types: &ScaleEncodeResolver,
                 __encode_as_type_out: &mut #path_to_scale_encode::Vec<u8>
             ) -> Result<(), #path_to_scale_encode::Error> {

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -30,8 +30,8 @@ bits = ["dep:scale-bits"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-type-resolver = { version = "0.1.1", default-features = false, features = ["visitor"] }
-scale-bits = { version = "0.5.0", default-features = false, optional = true }
+scale-type-resolver = { version = "0.2.0", default-features = false, features = ["visitor"] }
+scale-bits = { version = "0.6.0", default-features = false, optional = true }
 scale-encode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"
@@ -45,4 +45,4 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 trybuild = "1.0.72"
 # enable scale-info feature for testing:
 primitive-types = { version = "0.12.0", default-features = false, features = ["scale-info"] }
-scale-type-resolver = { version = "0.1.1", default-features = false, features = ["scale-info"] }
+scale-type-resolver = { version = "0.2.0", default-features = false, features = ["scale-info"] }

--- a/scale-encode/src/impls/composite.rs
+++ b/scale-encode/src/impls/composite.rs
@@ -27,7 +27,7 @@ use scale_type_resolver::visitor;
 trait EncodeAsTypeWithResolver<R: TypeResolver> {
     fn encode_as_type_with_resolver_to(
         &self,
-        type_id: &R::TypeId,
+        type_id: R::TypeId,
         types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error>;
@@ -35,7 +35,7 @@ trait EncodeAsTypeWithResolver<R: TypeResolver> {
 impl<T: EncodeAsType, R: TypeResolver> EncodeAsTypeWithResolver<R> for T {
     fn encode_as_type_with_resolver_to(
         &self,
-        type_id: &R::TypeId,
+        type_id: R::TypeId,
         types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
@@ -73,7 +73,7 @@ impl<'a, R: TypeResolver> CompositeField<'a, R> {
     /// SCALE encode this composite field to bytes based on the underlying type.
     pub fn encode_composite_field_to(
         &self,
-        type_id: &R::TypeId,
+        type_id: R::TypeId,
         types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
@@ -99,7 +99,7 @@ impl<'a, R: TypeResolver> CompositeField<'a, R> {
 /// impl EncodeAsType for MyType {
 ///     fn encode_as_type_to<R: TypeResolver>(
 ///         &self,
-///         type_id: &R::TypeId,
+///         type_id: R::TypeId,
 ///         types: &R,
 ///         out: &mut Vec<u8>
 ///     ) -> Result<(), Error> {
@@ -150,7 +150,7 @@ where
     /// allocates a [`Vec`] and returns it.
     pub fn encode_composite_as_type(
         &self,
-        type_id: &R::TypeId,
+        type_id: R::TypeId,
         types: &R,
     ) -> Result<Vec<u8>, Error> {
         let mut out = Vec::new();
@@ -161,7 +161,7 @@ where
     /// Encode this composite value as the provided type to the output bytes.
     pub fn encode_composite_as_type_to(
         &self,
-        type_id: &R::TypeId,
+        type_id: R::TypeId,
         types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error> {
@@ -172,27 +172,32 @@ where
         // are names, we may want to line up input field(s) on them.
         let type_id = skip_through_single_unnamed_fields(type_id, types);
 
-        let v = visitor::new((out, vals_iter), |(out, mut vals_iter), _| {
-            // Rather than immediately giving up, we should at least see whether
-            // we can skip one level in to our value and encode that.
-            if vals_iter_len == 1 {
-                return vals_iter
-                    .next()
-                    .expect("1 value expected")
-                    .1
-                    .encode_composite_field_to(type_id, types, out);
-            }
+        let v = visitor::new(
+            (type_id.clone(), out, vals_iter),
+            |(type_id, out, mut vals_iter), _| {
+                // Rather than immediately giving up, we should at least see whether
+                // we can skip one level in to our value and encode that.
+                if vals_iter_len == 1 {
+                    return vals_iter
+                        .next()
+                        .expect("1 value expected")
+                        .1
+                        .encode_composite_field_to(type_id, types, out);
+                }
 
-            // If we get here, then it means the value we were given had more than
-            // one field, and the type we were given was ultimately some one-field thing
-            // that contained a non composite/tuple type, so it would never work out.
-            Err(Error::new(ErrorKind::WrongShape {
-                actual: Kind::Struct,
-                expected_id: format!("{type_id:?}"),
-            }))
+                // If we get here, then it means the value we were given had more than
+                // one field, and the type we were given was ultimately some one-field thing
+                // that contained a non composite/tuple type, so it would never work out.
+                Err(Error::new(ErrorKind::WrongShape {
+                    actual: Kind::Struct,
+                    expected_id: format!("{type_id:?}"),
+                }))
+            },
+        )
+        .visit_not_found(|(type_id, _, _)| {
+            Err(Error::new(ErrorKind::TypeNotFound(format!("{type_id:?}"))))
         })
-        .visit_not_found(|_| Err(Error::new(ErrorKind::TypeNotFound(format!("{type_id:?}")))))
-        .visit_composite(|(out, mut vals_iter), mut fields| {
+        .visit_composite(|(type_id, out, mut vals_iter), _, mut fields| {
             // If vals are named, we may need to line them up with some named composite.
             // If they aren't named, we only care about lining up based on matching lengths.
             let is_named_vals = vals_iter.clone().any(|(name, _)| name.is_some());
@@ -209,7 +214,7 @@ where
 
             self.encode_composite_fields_to(&mut fields, types, out)
         })
-        .visit_tuple(|(out, mut vals_iter), type_ids| {
+        .visit_tuple(|(type_id, out, mut vals_iter), type_ids| {
             // If there is exactly one val, it won't line up with the tuple then, so
             // try encoding one level in instead.
             if vals_iter_len == 1 {
@@ -301,7 +306,7 @@ where
             }
 
             for (idx, (field, (name, val))) in fields.iter().zip(vals_iter).enumerate() {
-                val.encode_composite_field_to(field.id, types, out)
+                val.encode_composite_field_to(field.id.clone(), types, out)
                     .map_err(|e| {
                         let loc = if let Some(name) = name {
                             Location::field(name.to_string())
@@ -319,11 +324,11 @@ where
 // Single unnamed fields carry no useful information and can be skipped through.
 // Single named fields may still be useful to line up with named composites.
 fn skip_through_single_unnamed_fields<'a, R: TypeResolver>(
-    type_id: &'a R::TypeId,
+    type_id: R::TypeId,
     types: &'a R,
-) -> &'a R::TypeId {
-    let v = visitor::new((), |_, _| type_id)
-        .visit_composite(|_, fields| {
+) -> R::TypeId {
+    let v = visitor::new(type_id.clone(), |type_id, _| type_id)
+        .visit_composite(|type_id, _, fields| {
             // If exactly 1 unnamed field, recurse into it, else return current type ID.
             let Some(f) = fields.next() else {
                 return type_id;
@@ -333,7 +338,7 @@ fn skip_through_single_unnamed_fields<'a, R: TypeResolver>(
             };
             skip_through_single_unnamed_fields(f.id, types)
         })
-        .visit_tuple(|_, type_ids| {
+        .visit_tuple(|type_id, type_ids| {
             // Else if exactly 1 tuple entry, recurse into it, else return current type ID.
             let Some(new_type_id) = type_ids.next() else {
                 return type_id;
@@ -344,5 +349,5 @@ fn skip_through_single_unnamed_fields<'a, R: TypeResolver>(
             skip_through_single_unnamed_fields(new_type_id, types)
         });
 
-    types.resolve_type(type_id, v).unwrap_or(type_id)
+    types.resolve_type(type_id.clone(), v).unwrap_or(type_id)
 }

--- a/scale-encode/src/impls/composite.rs
+++ b/scale-encode/src/impls/composite.rs
@@ -323,10 +323,7 @@ where
 
 // Single unnamed fields carry no useful information and can be skipped through.
 // Single named fields may still be useful to line up with named composites.
-fn skip_through_single_unnamed_fields<'a, R: TypeResolver>(
-    type_id: R::TypeId,
-    types: &'a R,
-) -> R::TypeId {
+fn skip_through_single_unnamed_fields<R: TypeResolver>(type_id: R::TypeId, types: &R) -> R::TypeId {
     let v = visitor::new(type_id.clone(), |type_id, _| type_id)
         .visit_composite(|type_id, _, fields| {
             // If exactly 1 unnamed field, recurse into it, else return current type ID.

--- a/scale-encode/src/impls/mod.rs
+++ b/scale-encode/src/impls/mod.rs
@@ -496,10 +496,7 @@ impl_encode_like!(Compact<T> as &T where |val| &val.0);
 // Attempt to recurse into some type, returning the innermost type found that has an identical
 // SCALE encoded representation to the given type. For instance, `(T,)` encodes identically to
 // `T`, as does `Mytype { inner: T }` or `[T; 1]`.
-fn find_single_entry_with_same_repr<'a, R: TypeResolver>(
-    type_id: R::TypeId,
-    types: &'a R,
-) -> R::TypeId {
+fn find_single_entry_with_same_repr<R: TypeResolver>(type_id: R::TypeId, types: &R) -> R::TypeId {
     let v = visitor::new(type_id.clone(), |type_id, _| type_id)
         .visit_tuple(|type_id, fields| {
             let Some(new_type_id) = fields.next() else {

--- a/scale-encode/src/impls/primitive_types.rs
+++ b/scale-encode/src/impls/primitive_types.rs
@@ -23,7 +23,7 @@ macro_rules! impl_encode {
         impl EncodeAsType for $ty {
             fn encode_as_type_to<R: TypeResolver>(
                 &self,
-                type_id: &R::TypeId,
+                type_id: R::TypeId,
                 types: &R,
                 out: &mut Vec<u8>,
             ) -> Result<(), Error> {

--- a/scale-encode/src/lib.rs
+++ b/scale-encode/src/lib.rs
@@ -59,7 +59,7 @@ where
     B: TypeInfo + Encode + 'static,
 {
     let (type_id, types) = get_type_info::<B>();
-    let a_bytes = a.encode_as_type(&type_id, &types).unwrap();
+    let a_bytes = a.encode_as_type(type_id, &types).unwrap();
     let b_bytes = b.encode();
     assert_eq!(a_bytes, b_bytes);
 }
@@ -170,7 +170,7 @@ pub trait EncodeAsType {
     /// attempt to SCALE encode the current value into the type given by `type_id`.
     fn encode_as_type_to<R: TypeResolver>(
         &self,
-        type_id: &R::TypeId,
+        type_id: R::TypeId,
         types: &R,
         out: &mut Vec<u8>,
     ) -> Result<(), Error>;
@@ -179,7 +179,7 @@ pub trait EncodeAsType {
     /// implement that instead.
     fn encode_as_type<R: TypeResolver>(
         &self,
-        type_id: &R::TypeId,
+        type_id: R::TypeId,
         types: &R,
     ) -> Result<Vec<u8>, Error> {
         let mut out = Vec::new();


### PR DESCRIPTION
Update the `scale-type-resolver` dependency to 0.2.0 (and bump `scale-bits` for the same reason).

The main change here is that type IDs are now passed by value, rather than reference.