### PR TITLE
Prep for 0.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [v0.7.1] - 2024-05-17
+
+- Implement EncodeAsFields for pointer types like Arc and Box([#22](https://github.com/paritytech/scale-encode/pull/22))
+
+
 ## [v0.7.0] - 2024-04-29
 
 Update the `scale-type-resolver` dependency to 0.2.0 (and bump `scale-bits` for the same reason).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [v0.7.1] - 2024-05-17
 
-- Implement EncodeAsFields for pointer types like Arc and Box([#22](https://github.com/paritytech/scale-encode/pull/22))
+- Implement EncodeAsFields for pointer types like Arc and Box ([#22](https://github.com/paritytech/scale-encode/pull/22))
 
 
 ## [v0.7.0] - 2024-04-29

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,9 @@
 [workspace]
-members = [
-    "scale-encode",
-    "scale-encode-derive",
-    "testing/no_std",
-]
+members = ["scale-encode", "scale-encode-derive", "testing/no_std"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -17,5 +13,5 @@ keywords = ["parity", "scale", "encoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [workspace.dependencies]
-scale-encode = { version = "0.7.0", path = "scale-encode" }
-scale-encode-derive = { version = "0.7.0", path = "scale-encode-derive" }
+scale-encode = { version = "0.7.1", path = "scale-encode" }
+scale-encode-derive = { version = "0.7.1", path = "scale-encode-derive" }


### PR DESCRIPTION
## [0.7.1] - 2024-05-17 
- Implement EncodeAsFields for pointer types like Arc and Box ([#22](https://github.com/paritytech/scale-encode/pull/22))