### PR TITLE
update some of the deps to use syn2

### DIFF
--- a/scale-encode-derive/Cargo.toml
+++ b/scale-encode-derive/Cargo.toml
@@ -17,8 +17,8 @@ include.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = { version = "1", features = ["full"] }
+syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
-proc-macro-crate = "1"
-darling = "0.14.2"
+proc-macro-crate = "3.1.0"
+darling = "0.20.9"

--- a/scale-encode-derive/src/lib.rs
+++ b/scale-encode-derive/src/lib.rs
@@ -13,6 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// https://github.com/rust-lang/rust-clippy/issues/12643.
+// related to `darling::default` attribute expansion
+#![allow(clippy::manual_unwrap_or_default)]
+
 use darling::FromAttributes;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
@@ -250,11 +254,11 @@ impl TopLevelAttrs {
 
         // look at each top level attr. parse any for encode_as_type.
         for attr in attrs {
-            if !attr.path.is_ident(ATTR_NAME) {
+            if !attr.path().is_ident(ATTR_NAME) {
                 continue;
             }
-            let meta = attr.parse_meta()?;
-            let parsed_attrs = TopLevelAttrsInner::from_meta(&meta)?;
+            let meta = &attr.meta;
+            let parsed_attrs = TopLevelAttrsInner::from_meta(meta)?;
 
             res.trait_bounds = parsed_attrs.trait_bounds;
             if let Some(crate_path) = parsed_attrs.crate_path {

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -35,7 +35,7 @@ scale-bits = { version = "0.6.0", default-features = false, optional = true }
 scale-encode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.12.0", optional = true, default-features = false }
 smallvec = "1.10.0"
-derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
+derive_more = { version = "0.99.18", default-features = false, features = ["from", "display"] }
 
 [dev-dependencies]
 bitvec = { version = "1.0.1", default-features = false }


### PR DESCRIPTION
### Description 
Now the only deps that pull in `syn@1` are parity-scale-codec and scale-info