### PR TITLE
chore: release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [v0.7.2] - 2024-10-18
+
+- Update dependencies `syn 2.0`, `darling 0.20` and `proc-macro-crate 3.1` ([#24](https://github.com/paritytech/scale-encode/pull/24))
+
 ## [v0.7.1] - 2024-05-17
 
 - Implement EncodeAsFields for pointer types like Arc and Box ([#22](https://github.com/paritytech/scale-encode/pull/22))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [v0.7.2] - 2024-10-18
+## [v0.7.2] - 2024-10-21
 
 - Update dependencies `syn 2.0`, `darling 0.20` and `proc-macro-crate 3.1` ([#24](https://github.com/paritytech/scale-encode/pull/24))
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["scale-encode", "scale-encode-derive", "testing/no_std"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -13,5 +13,5 @@ keywords = ["parity", "scale", "encoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [workspace.dependencies]
-scale-encode = { version = "0.7.1", path = "scale-encode" }
-scale-encode-derive = { version = "0.7.1", path = "scale-encode-derive" }
+scale-encode = { version = "0.7.2", path = "scale-encode" }
+scale-encode-derive = { version = "0.7.2", path = "scale-encode-derive" }


### PR DESCRIPTION
Third-party users such as subxt would benefit to not depend on old versions of `syn`, `darling` and `proc-macro-crate`.