### PR TITLE
use core::error::Error and make the crate no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/paritytech/scale-encode"
 homepage = "https://www.parity.io/"
 keywords = ["parity", "scale", "encoding"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
+rust-version = "1.81.0"
 
 [workspace.dependencies]
 scale-encode = { version = "0.8.0", path = "scale-encode" }

--- a/scale-encode-derive/Cargo.toml
+++ b/scale-encode-derive/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 include.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/scale-encode/Cargo.toml
+++ b/scale-encode/Cargo.toml
@@ -12,12 +12,10 @@ repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 include.workspace = true
+rust-version.workspace = true
 
 [features]
-default = ["std", "derive", "primitive-types", "bits"]
-
-# Activates std feature.
-std = []
+default = ["derive", "primitive-types", "bits"]
 
 # Include the derive proc macro.
 derive = ["dep:scale-encode-derive"]
@@ -35,7 +33,7 @@ scale-bits = { version = "0.6.0", default-features = false, optional = true }
 scale-encode-derive = { workspace = true, optional = true }
 primitive-types = { version = "0.13.1", optional = true, default-features = false }
 smallvec = "1.10.0"
-derive_more = { version = "1.0.0", default-features = false, features = ["from", "display"] }
+thiserror = { version = "2.0.0", default-features = false }
 
 [dev-dependencies]
 bitvec = { version = "1.0.1", default-features = false }

--- a/scale-encode/src/lib.rs
+++ b/scale-encode/src/lib.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 /*!
 `parity-scale-codec` provides an `Encode` trait which allows types to SCALE encode themselves based on their shape.


### PR DESCRIPTION
This PR changes:

- Remove std feature and replace it with core::error::Error
- Replace derive_more with thiserror (thiserror uses internally core::error::Error when rustc >= 1.81 is used)
- Add MSRV 1.81

